### PR TITLE
Remove the robots.txt file

### DIFF
--- a/tests/unit/static_content_test.py
+++ b/tests/unit/static_content_test.py
@@ -21,7 +21,6 @@ class TestStaticContent:
     @pytest.mark.parametrize(
         "url,mime_type",
         (
-            ("/robots.txt", "text/plain"),
             ("/favicon.ico", "image/x-icon"),
             ("/js/pdfjs-init.js", "text/javascript"),
         ),
@@ -38,7 +37,7 @@ class TestStaticContent:
     def test_immutable_contents(self, test_app):
         salt = self.get_salt(test_app)
 
-        response = test_app.get(f"/static/{salt}/robots.txt")
+        response = test_app.get(f"/static/{salt}/favicon.ico")
 
         assert_cache_control(
             response.headers, ["max-age=315360000", "public", "immutable"]

--- a/via/app.py
+++ b/via/app.py
@@ -61,7 +61,7 @@ def create_app(_=None, **settings):
 
     app.add_files(
         # Config for serving files at / which are marked as mutable. This is
-        # for robots.txt and / -> index.html
+        # for / -> index.html
         root=resource_filename("via", "static"),
         prefix="/",
     )

--- a/via/static/robots.txt
+++ b/via/static/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
Now that we've added noindex, nofollow tags to Via 3's headers (https://github.com/hypothesis/via3/pull/317) remove [Via 3's `/robots.txt` file](https://via3.hypothes.is/robots.txt) so that Google will actually fetch Via 3's pages and see the new tags.

Part of https://github.com/hypothesis/checkmate/issues/167

This turns `/robots.txt` into Via 3's standard 404 error page.

Testing:

* Open http://localhost:9083/robots.txt