### PR TITLE
Add `make shell`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ help:
 	@echo "make dev               Run the app in the development server"
 	@echo "make supervisor        Launch a supervisorctl shell for managing the processes "
 	@echo '                       that `make dev` starts, type `help` for docs'
+	@echo "make shell             Launch a Python shell in the dev environment"
 	@echo 'make services          Run the services that `make dev` requires'
 	@echo 'make build             Prepare the build files'
 	@echo "make lint              Run the code linter(s) and print any warnings"
@@ -28,6 +29,10 @@ supervisor: python
 .PHONY: devdata
 devdata: python
 	@tox -qe dev -- python bin/devdata.py
+
+.PHONY: shell
+shell: python
+	@tox -qe dev --run-command 'pshell conf/development.ini'
 
 .PHONY: build
 build: python

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
 -r requirements.txt
-ipython
+pyramid_ipython
 ipdb
 supervisor
 docker-compose

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,188 +4,68 @@
 #
 #    pip-compile requirements/dev.in
 #
-attrs==20.2.0
-    # via jsonschema
-backcall==0.2.0
-    # via ipython
-bcrypt==3.2.0
-    # via paramiko
-cached-property==1.5.1
-    # via docker-compose
-certifi==2020.6.20
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-    #   sentry-sdk
-cffi==1.14.2
-    # via
-    #   bcrypt
-    #   cryptography
-    #   pynacl
-chardet==3.0.4
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-cryptography==3.2
-    # via paramiko
-decorator==4.4.2
-    # via
-    #   ipython
-    #   traitlets
-distro==1.5.0
-    # via docker-compose
-docker-compose==1.28.2
-    # via -r requirements/dev.in
-docker[ssh]==4.4.1
-    # via docker-compose
-dockerpty==0.4.1
-    # via docker-compose
-docopt==0.6.2
-    # via docker-compose
-gunicorn==20.0.4
-    # via -r requirements/requirements.txt
-h-pyramid-sentry==1.2.1
-    # via -r requirements/requirements.txt
-h-vialib==1.0.1
-    # via -r requirements/requirements.txt
-hupper==1.10.2
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-idna==2.10
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-importlib-metadata==1.7.0
-    # via jsonschema
-ipdb==0.13.4
-    # via -r requirements/dev.in
-ipython-genutils==0.2.0
-    # via traitlets
-ipython==7.16.1
-    # via
-    #   -r requirements/dev.in
-    #   ipdb
-jedi==0.17.2
-    # via ipython
-jinja2==2.11.2
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid-jinja2
-jsonschema==3.2.0
-    # via docker-compose
-markupsafe==1.1.1
-    # via
-    #   -r requirements/requirements.txt
-    #   jinja2
-    #   pyramid-jinja2
-newrelic==6.0.1.155
-    # via -r requirements/requirements.txt
-paramiko==2.7.2
-    # via docker
-parso==0.7.1
-    # via jedi
-pastedeploy==2.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   plaster-pastedeploy
-pexpect==4.8.0
-    # via ipython
-pickleshare==0.7.5
-    # via ipython
-plaster-pastedeploy==0.7
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-plaster==1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   plaster-pastedeploy
-    #   pyramid
-prompt-toolkit==3.0.7
-    # via ipython
-ptyprocess==0.6.0
-    # via pexpect
-pycparser==2.20
-    # via cffi
-pygments==2.7.1
-    # via ipython
-pynacl==1.4.0
-    # via paramiko
-pyramid-jinja2==2.8
-    # via -r requirements/requirements.txt
-pyramid==1.10.5
-    # via
-    #   -r requirements/requirements.txt
-    #   h-pyramid-sentry
-    #   pyramid-jinja2
-pyrsistent==0.17.3
-    # via jsonschema
-python-dotenv==0.14.0
-    # via docker-compose
-pyyaml==5.3.1
-    # via docker-compose
-requests==2.25.1
-    # via
-    #   -r requirements/requirements.txt
-    #   docker
-    #   docker-compose
-sentry-sdk==0.17.6
-    # via
-    #   -r requirements/requirements.txt
-    #   h-pyramid-sentry
-six==1.15.0
-    # via
-    #   bcrypt
-    #   cryptography
-    #   docker
-    #   dockerpty
-    #   jsonschema
-    #   pynacl
-    #   traitlets
-    #   websocket-client
-supervisor==4.2.1
-    # via -r requirements/dev.in
-texttable==1.6.3
-    # via docker-compose
-traitlets==4.3.3
-    # via ipython
-translationstring==1.4
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-urllib3==1.25.10
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-    #   sentry-sdk
-venusian==3.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-wcwidth==0.2.5
-    # via prompt-toolkit
-webob==1.8.6
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-websocket-client==0.57.0
-    # via
-    #   docker
-    #   docker-compose
-whitenoise==5.2.0
-    # via -r requirements/requirements.txt
-zipp==3.1.0
-    # via importlib-metadata
-zope.deprecation==4.4.0
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-    #   pyramid-jinja2
-zope.interface==5.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
+attrs==20.2.0             # via jsonschema
+backcall==0.2.0           # via ipython
+bcrypt==3.2.0             # via paramiko
+cached-property==1.5.1    # via docker-compose
+certifi==2020.6.20        # via -r requirements/requirements.txt, requests, sentry-sdk
+cffi==1.14.2              # via bcrypt, cryptography, pynacl
+chardet==3.0.4            # via -r requirements/requirements.txt, requests
+cryptography==3.2         # via paramiko
+decorator==4.4.2          # via ipython, traitlets
+distro==1.5.0             # via docker-compose
+docker-compose==1.28.2    # via -r requirements/dev.in
+docker[ssh]==4.4.1        # via docker-compose
+dockerpty==0.4.1          # via docker-compose
+docopt==0.6.2             # via docker-compose
+gunicorn==20.0.4          # via -r requirements/requirements.txt
+h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
+h-vialib==1.0.1           # via -r requirements/requirements.txt
+hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
+idna==2.10                # via -r requirements/requirements.txt, requests
+importlib-metadata==1.7.0  # via jsonschema
+ipdb==0.13.4              # via -r requirements/dev.in
+ipython-genutils==0.2.0   # via traitlets
+ipython==7.16.1           # via ipdb, pyramid-ipython
+jedi==0.17.2              # via ipython
+jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
+jsonschema==3.2.0         # via docker-compose
+markupsafe==1.1.1         # via -r requirements/requirements.txt, jinja2, pyramid-jinja2
+newrelic==6.0.1.155       # via -r requirements/requirements.txt
+paramiko==2.7.2           # via docker
+parso==0.7.1              # via jedi
+pastedeploy==2.1.0        # via -r requirements/requirements.txt, plaster-pastedeploy
+pexpect==4.8.0            # via ipython
+pickleshare==0.7.5        # via ipython
+plaster-pastedeploy==0.7  # via -r requirements/requirements.txt, pyramid
+plaster==1.0              # via -r requirements/requirements.txt, plaster-pastedeploy, pyramid
+prompt-toolkit==3.0.7     # via ipython
+ptyprocess==0.6.0         # via pexpect
+pycparser==2.20           # via cffi
+pygments==2.7.1           # via ipython
+pynacl==1.4.0             # via paramiko
+pyramid-ipython==0.2      # via -r requirements/dev.in
+pyramid-jinja2==2.8       # via -r requirements/requirements.txt
+pyramid==1.10.5           # via -r requirements/requirements.txt, h-pyramid-sentry, pyramid-ipython, pyramid-jinja2
+pyrsistent==0.17.3        # via jsonschema
+python-dotenv==0.14.0     # via docker-compose
+pyyaml==5.3.1             # via docker-compose
+requests==2.25.1          # via -r requirements/requirements.txt, docker, docker-compose
+sentry-sdk==0.17.6        # via -r requirements/requirements.txt, h-pyramid-sentry
+six==1.15.0               # via bcrypt, cryptography, docker, dockerpty, jsonschema, pynacl, traitlets, websocket-client
+supervisor==4.2.1         # via -r requirements/dev.in
+texttable==1.6.3          # via docker-compose
+traitlets==4.3.3          # via ipython
+translationstring==1.4    # via -r requirements/requirements.txt, pyramid
+urllib3==1.25.10          # via -r requirements/requirements.txt, requests, sentry-sdk
+venusian==3.0.0           # via -r requirements/requirements.txt, pyramid
+wcwidth==0.2.5            # via prompt-toolkit
+webob==1.8.6              # via -r requirements/requirements.txt, pyramid
+websocket-client==0.57.0  # via docker, docker-compose
+whitenoise==5.2.0         # via -r requirements/requirements.txt
+zipp==3.1.0               # via importlib-metadata
+zope.deprecation==4.4.0   # via -r requirements/requirements.txt, pyramid, pyramid-jinja2
+zope.interface==5.1.0     # via -r requirements/requirements.txt, pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,231 +4,64 @@
 #
 #    pip-compile requirements/lint.in
 #
-astroid==2.4.2
-    # via pylint
-attrs==20.2.0
-    # via
-    #   -r requirements/tests.txt
-    #   pytest
-beautifulsoup4==4.9.1
-    # via
-    #   -r requirements/tests.txt
-    #   webtest
-certifi==2020.6.20
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   requests
-    #   sentry-sdk
-chardet==3.0.4
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   requests
-coverage==5.4
-    # via -r requirements/tests.txt
-factory-boy==3.2.0
-    # via -r requirements/tests.txt
-faker==4.1.2
-    # via
-    #   -r requirements/tests.txt
-    #   factory-boy
-gunicorn==20.0.4
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-h-matchers==1.2.10
-    # via -r requirements/tests.txt
-h-pyramid-sentry==1.2.1
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-h-vialib==1.0.1
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-htmlmin==0.1.12
-    # via -r requirements/lint.in
-httpretty==1.0.5
-    # via -r requirements/tests.txt
-hupper==1.10.2
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
-idna==2.10
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   requests
-importlib-metadata==1.7.0
-    # via
-    #   -r requirements/tests.txt
-    #   pluggy
-    #   pytest
-iniconfig==1.0.1
-    # via
-    #   -r requirements/tests.txt
-    #   pytest
-isort==5.7.0
-    # via pylint
-jinja2==2.11.2
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid-jinja2
-lazy-object-proxy==1.4.3
-    # via astroid
-markupsafe==1.1.1
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   jinja2
-    #   pyramid-jinja2
-mccabe==0.6.1
-    # via pylint
-newrelic==6.0.1.155
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-packaging==20.4
-    # via
-    #   -r requirements/tests.txt
-    #   pytest
-pastedeploy==2.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   plaster-pastedeploy
-plaster-pastedeploy==0.7
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
-plaster==1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   plaster-pastedeploy
-    #   pyramid
-pluggy==0.13.1
-    # via
-    #   -r requirements/tests.txt
-    #   pytest
-py==1.9.0
-    # via
-    #   -r requirements/tests.txt
-    #   pytest
-pydocstyle==5.1.1
-    # via -r requirements/lint.in
-pylint==2.6.0
-    # via -r requirements/lint.in
-pyparsing==2.4.7
-    # via
-    #   -r requirements/tests.txt
-    #   packaging
-pyramid-jinja2==2.8
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-pyramid==1.10.5
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   h-pyramid-sentry
-    #   pyramid-jinja2
-pytest==6.2.2
-    # via -r requirements/tests.txt
-python-dateutil==2.8.1
-    # via
-    #   -r requirements/tests.txt
-    #   faker
-rcssmin==1.0.6
-    # via -r requirements/lint.in
-requests==2.25.1
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-rjsmin==1.1.0
-    # via -r requirements/lint.in
-sentry-sdk==0.17.6
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   h-pyramid-sentry
-six==1.15.0
-    # via
-    #   -r requirements/tests.txt
-    #   astroid
-    #   packaging
-    #   python-dateutil
-    #   webtest
-snowballstemmer==2.0.0
-    # via pydocstyle
-soupsieve==2.0.1
-    # via
-    #   -r requirements/tests.txt
-    #   beautifulsoup4
-text-unidecode==1.3
-    # via
-    #   -r requirements/tests.txt
-    #   faker
-toml==0.10.1
-    # via
-    #   -r requirements/tests.txt
-    #   pylint
-    #   pytest
-translationstring==1.4
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
-typed-ast==1.4.1
-    # via astroid
-urllib3==1.25.10
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   requests
-    #   sentry-sdk
-venusian==3.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
-waitress==1.4.4
-    # via
-    #   -r requirements/tests.txt
-    #   webtest
-webob==1.8.6
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
-    #   webtest
-webtest==2.0.35
-    # via -r requirements/tests.txt
-whitenoise==5.2.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-wrapt==1.11.2
-    # via astroid
-zipp==3.1.0
-    # via
-    #   -r requirements/tests.txt
-    #   importlib-metadata
-zope.deprecation==4.4.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
-    #   pyramid-jinja2
-zope.interface==5.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   pyramid
+astroid==2.4.2            # via pylint
+attrs==20.2.0             # via -r requirements/tests.txt, pytest
+beautifulsoup4==4.9.1     # via -r requirements/tests.txt, webtest
+certifi==2020.6.20        # via -r requirements/requirements.txt, -r requirements/tests.txt, requests, sentry-sdk
+chardet==3.0.4            # via -r requirements/requirements.txt, -r requirements/tests.txt, requests
+coverage==5.4             # via -r requirements/tests.txt
+factory-boy==3.2.0        # via -r requirements/tests.txt
+faker==4.1.2              # via -r requirements/tests.txt, factory-boy
+gunicorn==20.0.4          # via -r requirements/requirements.txt, -r requirements/tests.txt
+h-matchers==1.2.10        # via -r requirements/tests.txt
+h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt, -r requirements/tests.txt
+h-vialib==1.0.1           # via -r requirements/requirements.txt, -r requirements/tests.txt
+htmlmin==0.1.12           # via -r requirements/lint.in
+httpretty==1.0.5          # via -r requirements/tests.txt
+hupper==1.10.2            # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
+idna==2.10                # via -r requirements/requirements.txt, -r requirements/tests.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/tests.txt, pluggy, pytest
+iniconfig==1.0.1          # via -r requirements/tests.txt, pytest
+isort==5.7.0              # via pylint
+jinja2==2.11.2            # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid-jinja2
+lazy-object-proxy==1.4.3  # via astroid
+markupsafe==1.1.1         # via -r requirements/requirements.txt, -r requirements/tests.txt, jinja2, pyramid-jinja2
+mccabe==0.6.1             # via pylint
+newrelic==6.0.1.155       # via -r requirements/requirements.txt, -r requirements/tests.txt
+packaging==20.4           # via -r requirements/tests.txt, pytest
+pastedeploy==2.1.0        # via -r requirements/requirements.txt, -r requirements/tests.txt, plaster-pastedeploy
+plaster-pastedeploy==0.7  # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
+plaster==1.0              # via -r requirements/requirements.txt, -r requirements/tests.txt, plaster-pastedeploy, pyramid
+pluggy==0.13.1            # via -r requirements/tests.txt, pytest
+py==1.9.0                 # via -r requirements/tests.txt, pytest
+pydocstyle==5.1.1         # via -r requirements/lint.in
+pylint==2.6.0             # via -r requirements/lint.in
+pyparsing==2.4.7          # via -r requirements/tests.txt, packaging
+pyramid-jinja2==2.8       # via -r requirements/requirements.txt, -r requirements/tests.txt
+pyramid==1.10.5           # via -r requirements/requirements.txt, -r requirements/tests.txt, h-pyramid-sentry, pyramid-jinja2
+pytest==6.2.2             # via -r requirements/tests.txt
+python-dateutil==2.8.1    # via -r requirements/tests.txt, faker
+rcssmin==1.0.6            # via -r requirements/lint.in
+requests==2.25.1          # via -r requirements/requirements.txt, -r requirements/tests.txt
+rjsmin==1.1.0             # via -r requirements/lint.in
+sentry-sdk==0.17.6        # via -r requirements/requirements.txt, -r requirements/tests.txt, h-pyramid-sentry
+six==1.15.0               # via -r requirements/tests.txt, astroid, packaging, python-dateutil, webtest
+snowballstemmer==2.0.0    # via pydocstyle
+soupsieve==2.0.1          # via -r requirements/tests.txt, beautifulsoup4
+text-unidecode==1.3       # via -r requirements/tests.txt, faker
+toml==0.10.1              # via -r requirements/tests.txt, pylint, pytest
+translationstring==1.4    # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.10          # via -r requirements/requirements.txt, -r requirements/tests.txt, requests, sentry-sdk
+venusian==3.0.0           # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
+waitress==1.4.4           # via -r requirements/tests.txt, webtest
+webob==1.8.6              # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid, webtest
+webtest==2.0.35           # via -r requirements/tests.txt
+whitenoise==5.2.0         # via -r requirements/requirements.txt, -r requirements/tests.txt
+wrapt==1.11.2             # via astroid
+zipp==3.1.0               # via -r requirements/tests.txt, importlib-metadata
+zope.deprecation==4.4.0   # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid, pyramid-jinja2
+zope.interface==5.1.0     # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,67 +4,30 @@
 #
 #    pip-compile requirements/requirements.in
 #
-certifi==2020.6.20
-    # via
-    #   requests
-    #   sentry-sdk
-chardet==3.0.4
-    # via requests
-gunicorn==20.0.4
-    # via -r requirements/requirements.in
-h-pyramid-sentry==1.2.1
-    # via -r requirements/requirements.in
-h-vialib==1.0.1
-    # via -r requirements/requirements.in
-hupper==1.10.2
-    # via pyramid
-idna==2.10
-    # via requests
-jinja2==2.11.2
-    # via pyramid-jinja2
-markupsafe==1.1.1
-    # via
-    #   jinja2
-    #   pyramid-jinja2
-newrelic==6.0.1.155
-    # via -r requirements/requirements.in
-pastedeploy==2.1.0
-    # via plaster-pastedeploy
-plaster-pastedeploy==0.7
-    # via pyramid
-plaster==1.0
-    # via
-    #   plaster-pastedeploy
-    #   pyramid
-pyramid-jinja2==2.8
-    # via -r requirements/requirements.in
-pyramid==1.10.5
-    # via
-    #   -r requirements/requirements.in
-    #   h-pyramid-sentry
-    #   pyramid-jinja2
-requests==2.25.1
-    # via -r requirements/requirements.in
-sentry-sdk==0.17.6
-    # via h-pyramid-sentry
-translationstring==1.4
-    # via pyramid
-urllib3==1.25.10
-    # via
-    #   requests
-    #   sentry-sdk
-venusian==3.0.0
-    # via pyramid
-webob==1.8.6
-    # via pyramid
-whitenoise==5.2.0
-    # via -r requirements/requirements.in
-zope.deprecation==4.4.0
-    # via
-    #   pyramid
-    #   pyramid-jinja2
-zope.interface==5.1.0
-    # via pyramid
+certifi==2020.6.20        # via requests, sentry-sdk
+chardet==3.0.4            # via requests
+gunicorn==20.0.4          # via -r requirements/requirements.in
+h-pyramid-sentry==1.2.1   # via -r requirements/requirements.in
+h-vialib==1.0.1           # via -r requirements/requirements.in
+hupper==1.10.2            # via pyramid
+idna==2.10                # via requests
+jinja2==2.11.2            # via pyramid-jinja2
+markupsafe==1.1.1         # via jinja2, pyramid-jinja2
+newrelic==6.0.1.155       # via -r requirements/requirements.in
+pastedeploy==2.1.0        # via plaster-pastedeploy
+plaster-pastedeploy==0.7  # via pyramid
+plaster==1.0              # via plaster-pastedeploy, pyramid
+pyramid-jinja2==2.8       # via -r requirements/requirements.in
+pyramid==1.10.5           # via -r requirements/requirements.in, h-pyramid-sentry, pyramid-jinja2
+requests==2.25.1          # via -r requirements/requirements.in
+sentry-sdk==0.17.6        # via h-pyramid-sentry
+translationstring==1.4    # via pyramid
+urllib3==1.25.10          # via requests, sentry-sdk
+venusian==3.0.0           # via pyramid
+webob==1.8.6              # via pyramid
+whitenoise==5.2.0         # via -r requirements/requirements.in
+zope.deprecation==4.4.0   # via pyramid, pyramid-jinja2
+zope.interface==5.1.0     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,144 +4,52 @@
 #
 #    pip-compile requirements/tests.in
 #
-attrs==20.2.0
-    # via pytest
-beautifulsoup4==4.9.1
-    # via webtest
-certifi==2020.6.20
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-    #   sentry-sdk
-chardet==3.0.4
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-coverage==5.4
-    # via -r requirements/tests.in
-factory-boy==3.2.0
-    # via -r requirements/tests.in
-faker==4.1.2
-    # via factory-boy
-gunicorn==20.0.4
-    # via -r requirements/requirements.txt
-h-matchers==1.2.10
-    # via -r requirements/tests.in
-h-pyramid-sentry==1.2.1
-    # via -r requirements/requirements.txt
-h-vialib==1.0.1
-    # via -r requirements/requirements.txt
-httpretty==1.0.5
-    # via -r requirements/tests.in
-hupper==1.10.2
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-idna==2.10
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-importlib-metadata==1.7.0
-    # via
-    #   pluggy
-    #   pytest
-iniconfig==1.0.1
-    # via pytest
-jinja2==2.11.2
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid-jinja2
-markupsafe==1.1.1
-    # via
-    #   -r requirements/requirements.txt
-    #   jinja2
-    #   pyramid-jinja2
-newrelic==6.0.1.155
-    # via -r requirements/requirements.txt
-packaging==20.4
-    # via pytest
-pastedeploy==2.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   plaster-pastedeploy
-plaster-pastedeploy==0.7
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-plaster==1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   plaster-pastedeploy
-    #   pyramid
-pluggy==0.13.1
-    # via pytest
-py==1.9.0
-    # via pytest
-pyparsing==2.4.7
-    # via packaging
-pyramid-jinja2==2.8
-    # via -r requirements/requirements.txt
-pyramid==1.10.5
-    # via
-    #   -r requirements/requirements.txt
-    #   h-pyramid-sentry
-    #   pyramid-jinja2
-pytest==6.2.2
-    # via -r requirements/tests.in
-python-dateutil==2.8.1
-    # via faker
-requests==2.25.1
-    # via -r requirements/requirements.txt
-sentry-sdk==0.17.6
-    # via
-    #   -r requirements/requirements.txt
-    #   h-pyramid-sentry
-six==1.15.0
-    # via
-    #   packaging
-    #   python-dateutil
-    #   webtest
-soupsieve==2.0.1
-    # via beautifulsoup4
-text-unidecode==1.3
-    # via faker
-toml==0.10.1
-    # via pytest
-translationstring==1.4
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-urllib3==1.25.10
-    # via
-    #   -r requirements/requirements.txt
-    #   requests
-    #   sentry-sdk
-venusian==3.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-waitress==1.4.4
-    # via webtest
-webob==1.8.6
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-    #   webtest
-webtest==2.0.35
-    # via -r requirements/tests.in
-whitenoise==5.2.0
-    # via -r requirements/requirements.txt
-zipp==3.1.0
-    # via importlib-metadata
-zope.deprecation==4.4.0
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
-    #   pyramid-jinja2
-zope.interface==5.1.0
-    # via
-    #   -r requirements/requirements.txt
-    #   pyramid
+attrs==20.2.0             # via pytest
+beautifulsoup4==4.9.1     # via webtest
+certifi==2020.6.20        # via -r requirements/requirements.txt, requests, sentry-sdk
+chardet==3.0.4            # via -r requirements/requirements.txt, requests
+coverage==5.4             # via -r requirements/tests.in
+factory-boy==3.2.0        # via -r requirements/tests.in
+faker==4.1.2              # via factory-boy
+gunicorn==20.0.4          # via -r requirements/requirements.txt
+h-matchers==1.2.10        # via -r requirements/tests.in
+h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
+h-vialib==1.0.1           # via -r requirements/requirements.txt
+httpretty==1.0.5          # via -r requirements/tests.in
+hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
+idna==2.10                # via -r requirements/requirements.txt, requests
+importlib-metadata==1.7.0  # via pluggy, pytest
+iniconfig==1.0.1          # via pytest
+jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
+markupsafe==1.1.1         # via -r requirements/requirements.txt, jinja2, pyramid-jinja2
+newrelic==6.0.1.155       # via -r requirements/requirements.txt
+packaging==20.4           # via pytest
+pastedeploy==2.1.0        # via -r requirements/requirements.txt, plaster-pastedeploy
+plaster-pastedeploy==0.7  # via -r requirements/requirements.txt, pyramid
+plaster==1.0              # via -r requirements/requirements.txt, plaster-pastedeploy, pyramid
+pluggy==0.13.1            # via pytest
+py==1.9.0                 # via pytest
+pyparsing==2.4.7          # via packaging
+pyramid-jinja2==2.8       # via -r requirements/requirements.txt
+pyramid==1.10.5           # via -r requirements/requirements.txt, h-pyramid-sentry, pyramid-jinja2
+pytest==6.2.2             # via -r requirements/tests.in
+python-dateutil==2.8.1    # via faker
+requests==2.25.1          # via -r requirements/requirements.txt
+sentry-sdk==0.17.6        # via -r requirements/requirements.txt, h-pyramid-sentry
+six==1.15.0               # via packaging, python-dateutil, webtest
+soupsieve==2.0.1          # via beautifulsoup4
+text-unidecode==1.3       # via faker
+toml==0.10.1              # via pytest
+translationstring==1.4    # via -r requirements/requirements.txt, pyramid
+urllib3==1.25.10          # via -r requirements/requirements.txt, requests, sentry-sdk
+venusian==3.0.0           # via -r requirements/requirements.txt, pyramid
+waitress==1.4.4           # via webtest
+webob==1.8.6              # via -r requirements/requirements.txt, pyramid, webtest
+webtest==2.0.35           # via -r requirements/tests.in
+whitenoise==5.2.0         # via -r requirements/requirements.txt
+zipp==3.1.0               # via importlib-metadata
+zope.deprecation==4.4.0   # via -r requirements/requirements.txt, pyramid, pyramid-jinja2
+zope.interface==5.1.0     # via -r requirements/requirements.txt, pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
For some reason our usual `make shell` command was missing from Via 3, so add it.

`make shell` is a handy command that gives you an IPython shell _in the apps' dev venv_ so you can import the app and its dependencies etc.

It uses Pyramid's `pshell` (except in non-Pyramid projects, such as libraries, where `make shell` just runs `ipython` directly):

https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/commandline.html#pshell-the-interactive-shell

You can also customize the `make shell` environment to add handy things to it. I haven't added anything for Via 3 yet but see LMS for an example:

https://github.com/hypothesis/lms/blob/master/lms/pshell.py#L20-L30