### PR TITLE
Disable proxy error intercept

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
         merge_slashes off;
 
         location ~ /proxy/static/ {
-            proxy_intercept_errors on;
+            proxy_intercept_errors off;
             error_page 301 302 307 = @handle_redirect;
 
             # Handle most errors upstream listed at:


### PR DESCRIPTION
This may help us with debugging an issue causing failures fetching PDFs
via Google Drive in production.

For context, see https://hypothes-is.slack.com/archives/C4K6M7P5E/p1612200810247600