### PR TITLE
Revert "Disable proxy error intercept"

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
         merge_slashes off;
 
         location ~ /proxy/static/ {
-            proxy_intercept_errors off;
+            proxy_intercept_errors on;
             error_page 301 302 307 = @handle_redirect;
 
             # Handle most errors upstream listed at:


### PR DESCRIPTION
Reverts hypothesis/via3#328. Disabling `proxy_error_intercept` disables our special handling of redirects which is needed to prevent redirects from being cached, see: https://github.com/hypothesis/lms/issues/1448