### PR TITLE
Remove cookie and auth header stripping

### DIFF
--- a/conf/nginx/includes/direct_proxy.conf
+++ b/conf/nginx/includes/direct_proxy.conf
@@ -32,21 +32,6 @@ proxy_pass $uri$is_args$args;
 proxy_redirect ~^(https?:\/\/)(.*)$ $original_scheme://$http_host/proxy/static/$1$2;
 proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/https://$proxy_host$1;
 
-# Strip hypothesis cookies and authorization header.
-set $stripped_cookie $http_cookie;
-
-if ($stripped_cookie ~ "(.*)\s*auth=[^;]+;?(.*)") {
-    set $stripped_cookie $1$2;
-}
-if ($stripped_cookie ~ "(.*)\s*session=[^;]+;?(.*)") {
-    set $stripped_cookie $1$2;
-}
-proxy_set_header Cookie $stripped_cookie;
-proxy_set_header Authorization "";
-
-# Do not allow the third party server to set cookies.
-add_header "Set-Cookie" "";
-
 # Prevent the third party from adding CORS controls
 proxy_hide_header "Access-Control-Allow-Origin";
 proxy_hide_header "Access-Control-Allow-Credentials";


### PR DESCRIPTION
I don't think the cookie stripping actually works -- the `if`'s are skipped because of the `break` above. We may actually want to strip cookies so that we don't send our own `*.hypothes.is`-domain cookies (such as sensitive session or auth cookies) on to third-party servers. But these `if`'s don't work in this location in the nginx config.

I don't think the `Authorization` header stripping is necessary. Requests to Via 3's nginx endpoint don't include `Authorization` headers: the request is sent by PDF.js's JavaScript code. It could be a security thing--maybe stripping `Authorization` headers prevent Via 3 being abused to attack API's or something? But we're planning on locking this endpoint down using secure links anyway.

I'm not sure what the `Set-Cookie` header stripping is for. Apparently we don't want third-party sites to be able to set cookies, when being browsed in Via? But why? Won't this break sites? And in future we *do* want LMS users to annotate content that requires them to be logged in. It's probably not doing much harm right now because Via 3's nginx endpoint is only used for PDF's. But it doesn't seem like something we want.

Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1612293407380000