### PR TITLE
Remove the nginx keepalive_timeout setting

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -23,7 +23,6 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
     sendfile        on;
-    keepalive_timeout  65;
 
     # Configure the DNS that nginx uses to connect to the servers it's proxying.
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver


### PR DESCRIPTION
I don't know why this is here and can't find it in the history. It defaults to 75, but we felt the need to change it to 65? This looks very
likely unnecessary.

http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout