### PR TITLE
Use `return` instead of `try_files` in nginx config

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -124,23 +124,23 @@ http {
         }
 
         location @proxy_not_found {
-            # Not found / gone => 404 not found
-            try_files /proxy/not_found.html =404;
+            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
+            return 404;
         }
 
         location @proxy_too_many_requests {
-            # Too many requests => 429 too many requests
-            try_files /proxy/too_many_requests.html =429;
+            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
+            return 429;
         }
 
         location @proxy_client_error {
-            # All other 40x -> 400 bad request
-            try_files /proxy/client_error.html =400;
+            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
+            return 400;
         }
 
         location @proxy_upstream_error {
-            # All 50x -> 409 -> 409 conflict (with state of resource)
-            try_files /proxy/upstream_error.html =409;
+            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
+            return 409;
         }
 
         location / {


### PR DESCRIPTION
Use the nginx rewrite module's `return` directive instead of `try_files`.

It's simpler and `try_files` is confusing: I'm pretty sure the `not_found.html` in `try_files /proxy/not_found.html =404;` doesn't
exist in either Via 3 or NGINX and doesn't do anything.