### PR TITLE
Remove `proxy_redirect off`

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -159,8 +159,6 @@ http {
             # allow us to handle timeouts inside the app
             proxy_read_timeout 20s;
 
-            proxy_redirect off;
-
             # Send the full HTTP Host header (including the port) through to
             # the Gunicorn/Pyramid app.
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header


### PR DESCRIPTION
`proxy_redirect off` cancels any previously given `proxy_redirect`'s, but there aren't any previous `proxy_redirect`'s, so this does nothing.

> The off parameter cancels the effect of the proxy_redirect directives inherited from the previous configuration level.
>
> http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect