### PR TITLE
Use default nginx timeouts when proxying to gunicorn

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -151,13 +151,6 @@ http {
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version
             proxy_http_version 1.1;
 
-            proxy_connect_timeout 10s;
-            proxy_send_timeout 10s;
-            # This is how long we will wait for a response from the service
-            # This has to be longer than the time we wait for websites to
-            # allow us to handle timeouts inside the app
-            proxy_read_timeout 20s;
-
             # Send the full HTTP Host header (including the port) through to
             # the Gunicorn/Pyramid app.
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header


### PR DESCRIPTION
I see no reason why we need to change these from nginx's defaults.