### PR TITLE
Remove some headers that we're sending to gunicorn

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -125,11 +125,6 @@ http {
             # TODO: Why do we need to do this?
             proxy_set_header Host $http_host;
 
-            proxy_set_header X-Forwarded-Server $http_host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-            proxy_set_header X-Request-Start "t=${msec}";
-
             # Add an X-Via header for debugging.
             add_header "X-Via" "compute";
         }

--- a/via/get_url/headers.py
+++ b/via/get_url/headers.py
@@ -11,12 +11,9 @@ BANNED_HEADERS = {
     # AWS things
     "X-Amzn-Trace-Id",
     # AWS NGINX / NGINX things
-    "X-Forwarded-Server",
-    "X-Forwarded-For",
     "X-Real-Ip",
     "X-Forwarded-Proto",
     "X-Forwarded-Port",
-    "X-Request-Start",
     # Cloudflare things
     "Cf-Request-Id",
     "Cf-Connecting-Ip",


### PR DESCRIPTION
I don't think these are necessary? But I need to test to make sure that we don't break anything.

It looks like we also have some code in `headers.py` to prevent sending these headers on to third-parties, might be able to remove that too.