### PR TITLE
Use nginx's default pidfile location

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,10 +1,6 @@
 # Tell nginx not to daemonize (background) itself: http://nginx.org/en/docs/ngx_core_module.html#daemon
 daemon off;
 
-# Change the location of the file that stores nginx's process ID: http://nginx.org/en/docs/ngx_core_module.html#pid
-# TODO: Why do we change this?
-pid /var/lib/hypothesis/nginx.pid;
-
 # Log errors to stderr: http://nginx.org/en/docs/ngx_core_module.html#error_log
 error_log /dev/stderr;
 


### PR DESCRIPTION
`pid` is `logs/nginx.pid` by default:

http://nginx.org/en/docs/ngx_core_module.html#pid

I don't see why we need to change this? It looks like it might have been copied into Via 3 from h's nginx, but I don't see why we need to change it in h either.