### PR TITLE
Use nginx's default number of worker connections

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -9,15 +9,14 @@ pid /var/lib/hypothesis/nginx.pid;
 # Log errors to stderr: http://nginx.org/en/docs/ngx_core_module.html#error_log
 error_log /dev/stderr;
 
-# How many files a worker can open at once: http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
-# This has to be greater than or equal to worker_connections below.
-# TODO: Why have we chosen this number?
-worker_rlimit_nofile 7192;
-
 events {
     # How many connections a worker can open at once: http://nginx.org/en/docs/ngx_core_module.html#worker_connections
-    # TODO: Why have we chosen this number?
-    worker_connections  1024;
+    #
+    # This number hasn't been chosen for any particularly good reason. It's
+    # just an educated guess. The default of 512 seemed low and increasing it
+    # by 4x seemed like it might increase performance with little risk of
+    # breaking anything.
+    worker_connections  2048;
 }
 
 http {


### PR DESCRIPTION
...and open files.

I think it probably does make sense to tune these settings to match with our hardware, and I think nginx's defaults for these might be very conservative, so this PR is more of a placeholder for discussion rather than a serious suggestion that we just remove these.

* If we're going to set these I'd like there to be a comment explaining why the values were chosen
* I don't know why the particular numbers here were chosen
* I suspect they were chosen for reasons that never made sense or that at least don't make sense anymore (I think they came from Via 2 which was an entirely different beast, an OpenResty-based thing that did both PDF and HTML proxying, and probably ran on different EC2 instance types
* Are `worker_connections` and `worker_rlimit_nofile` the only two settings we should be tuning? We might want to consult an nginx tuning guide