### PR TITLE
Remove nginx static files settings

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -20,10 +20,6 @@ events {
 }
 
 http {
-    include       mime.types;
-    default_type  application/octet-stream;
-    sendfile        on;
-
     # Configure the DNS that nginx uses to connect to the servers it's proxying.
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
     # TODO: Do we need to change this? Why have we chosen this value?


### PR DESCRIPTION
Remove some nginx settings related to serving static files.

We don't serve static files through nginx. We have no reason to but if we ever do serve static files through nginx it's unlikely we'd do it like this: we'd probably group the static files settings together in their own `location { ... }`, and we'd read up on the best way to serve static files through nginx (are these three particular settings what we'd actually want?)

Changing the default mime type to text/plain to octet-stream seems particularly suspect.

In the spirit of keeping our nginx config file clean and fully understandable, free of noise and confusing unused settings, I'd like to remove these. I can't add a sensible comment to these explaining why they're here.