### PR TITLE
NGINX: Don't use Google's DNS

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -20,11 +20,6 @@ events {
 }
 
 http {
-    # Configure the DNS that nginx uses to connect to the servers it's proxying.
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
-    # TODO: Do we need to change this? Why have we chosen this value?
-    resolver 8.8.8.8 ipv6=off;
-
     # Log accesses to stdout: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
     access_log /dev/stdout;
 


### PR DESCRIPTION
When Via 3's NGINX needs to connect to the third-party servers it's being asked to proxy, don't use Google's public 8.8.8.8 DNS to look them up.

We do actually need to set `resolver` to something--by deleting it this commit actually breaks Via 3 at least in dev. So this is a placeholder for a discussion.  What DNS resolver should it use?

Note that it has to work both in production and in dev. We can potentially set this to different values in prod and dev though (or set
it to prod only not dev).