### PR TITLE
Deduplicate X-Robots-Tag header stuff

### DIFF
--- a/conf/nginx/includes/robots.conf
+++ b/conf/nginx/includes/robots.conf
@@ -1,0 +1,5 @@
+# Tell Google not to index the page and not to follow links on the page.
+#
+# https://developers.google.com/search/reference/robots_meta_tag
+
+add_header "X-Robots-Tag" "noindex, nofollow";

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -63,6 +63,9 @@ http {
         merge_slashes off;
 
         location ~ /proxy/static/ {
+            # We don't want our URLs that proxy third-party pages to show in Google.
+            include includes/robots.conf;
+
             # Intercept 3xx, 4xx and 5xx responses from the servers we're
             # proxying and process them through the error_page directives
             # below: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
@@ -99,10 +102,6 @@ http {
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "static-proxy, direct";
-
-            # Tell Google not to index or follow links on proxied pages.
-            # https://developers.google.com/search/reference/robots_meta_tag
-            add_header "X-Robots-Tag" "noindex, nofollow";
         }
 
         location @handle_redirect {
@@ -139,6 +138,12 @@ http {
         }
 
         location / {
+            # At least for now we don't want Via 3's non-proxy pages (including
+            # the front page) to show in Google. Later (when Via 3 replaces the
+            # public Via service) we'll probably want at least the front page
+            # to be indexable.
+            include includes/robots.conf;
+
             # Proxy to the Gunicorn/Pyramid app.
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
             proxy_pass http://web;
@@ -161,10 +166,6 @@ http {
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "compute";
-
-            # Tell Google not to index or follow links on proxied pages.
-            # https://developers.google.com/search/reference/robots_meta_tag
-            add_header "X-Robots-Tag" "noindex, nofollow";
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./conf/nginx/includes/direct_proxy.conf:/etc/nginx/includes/direct_proxy.conf:ro
+      - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro
       - ./conf/nginx/includes.dev/app_upstream.conf:/etc/nginx/includes/app_upstream.conf:ro
       - ./conf/nginx/dev_host_bridge.sh:/etc/nginx/dev_host_bridge.sh:ro
       - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template:ro


### PR DESCRIPTION
I'm also moving the `include`'s to the tops of their contexts, 'cos I got the idea that `include`'s could (mostly) be grouped together at the tops of contexts.