### PR TITLE
Follow redirects internally

### DIFF
--- a/conf/nginx/includes/cors.conf
+++ b/conf/nginx/includes/cors.conf
@@ -1,0 +1,7 @@
+# Prevent third-party servers from adding CORS controls.
+
+proxy_hide_header "Access-Control-Allow-Origin";
+proxy_hide_header "Access-Control-Allow-Credentials";
+proxy_hide_header "Access-Control-Allow-Methods";
+proxy_hide_header "Access-Control-Allow-Headers";
+proxy_hide_header "Access-Control-Expose-Headers";

--- a/conf/nginx/includes/direct_proxy.conf
+++ b/conf/nginx/includes/direct_proxy.conf
@@ -23,18 +23,3 @@ rewrite ^/proxy/static/(.*)$ $1? break;
 # The proxy directly to the resulting URL
 # Add back on the args which we stripped above so we don't get them twice
 proxy_pass $uri$is_args$args;
-
-# If the proxied server returns a redirect response change the URL in the
-# response's `Location` header to be proxied through us.
-# For example `Location: https://example.com` might get changed to
-# `Location: https://via3.hypothes.is/proxy/static/https://example.com`.
-# http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
-proxy_redirect ~^(https?:\/\/)(.*)$ $original_scheme://$http_host/proxy/static/$1$2;
-proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/https://$proxy_host$1;
-
-# Prevent the third party from adding CORS controls
-proxy_hide_header "Access-Control-Allow-Origin";
-proxy_hide_header "Access-Control-Allow-Credentials";
-proxy_hide_header "Access-Control-Allow-Methods";
-proxy_hide_header "Access-Control-Allow-Headers";
-proxy_hide_header "Access-Control-Expose-Headers";

--- a/conf/nginx/includes/errors.conf
+++ b/conf/nginx/includes/errors.conf
@@ -1,0 +1,37 @@
+# Follow chains of multiple redirects (when the requested URL redirects to
+# another URL which in turn redirects to another).
+#
+# This is limited to following up to 10 redirects.
+#
+# recursive_error_pages is also needed to enable our 4xx and 5xx error handling
+# to kick in when the requested URL redirects to a URL that 4xx's or 5xx's.
+#
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#recursive_error_pages
+recursive_error_pages on;
+
+# Intercept 3xx, 4xx and 5xx responses from the servers we're
+# proxying and process them through the error_page directives
+# below: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
+proxy_intercept_errors on;
+
+# Don't pass 3xx responses from the servers we're proxying back to
+# the browser. Instead process them through the @handle_redirect
+# location below.
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
+error_page 301 302 307 = @handle_redirect;
+
+# Don't pass 4xx or 5xx responses from the servers we're proxying
+# back to the browser. Instead process them through the @proxy_*
+# locations defined below.
+#
+# If users are proxying a third-party server that is returning
+# error responses we don't want Via 3 to return those same 4xx or
+# 5xx status codes to the browser because this would mess up our
+# monitoring and alerting. For example it might trigger an alarm
+# that Via 3 is unhealthy because it's sending too many error
+# responses.
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
+error_page 404 410 = @proxy_not_found;
+error_page 420 429 = @proxy_too_many_requests;
+error_page 400 401 402 403 405 406 407 408 409 411 412 413 414 415 416 417 418 422 423 424 425 426 428 431 444 449 450 451 = @proxy_client_error;
+error_page 500 501 502 503 504 505 506 507 508 509 510 511 598 599 = @proxy_upstream_error;

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -28,26 +28,6 @@ http {
     # Log accesses to stdout: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
     access_log /dev/stdout;
 
-    # Set $original_scheme to the protocol that the browser used to connect to Via
-    # ("http" or "https"), based on the X-Forwarded-Proto header. We'll need
-    # this variable later.
-    #
-    # $original_scheme is needed because AWS's load balancer connects to the
-    # app server using HTTP so nginx's default $scheme is always "http" in
-    # production.
-    #
-    # If there's no X-Forwarded-Proto header $original_scheme falls back to
-    # $scheme ("http").
-    #
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#var_http_
-    # http://nginx.org/en/docs/http/ngx_http_map_module.html#map
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#var_scheme
-    map $http_x_forwarded_proto $original_scheme {
-        "" $scheme;
-        default $http_x_forwarded_proto;
-    }
-
     include includes/app_upstream.conf;
 
     server {
@@ -66,34 +46,9 @@ http {
             # We don't want our URLs that proxy third-party pages to show in Google.
             include includes/robots.conf;
 
-            # Intercept 3xx, 4xx and 5xx responses from the servers we're
-            # proxying and process them through the error_page directives
-            # below: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
-            proxy_intercept_errors on;
-
-            # Don't pass 3xx responses from the servers we're proxying back to
-            # the browser. Instead process them through the @handle_redirect
-            # location below.
-            # http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
-            error_page 301 302 307 = @handle_redirect;
-
-            # Don't pass 4xx or 5xx responses from the servers we're proxying
-            # back to the browser. Instead process them through the @proxy_*
-            # locations defined below.
-            #
-            # If users are proxying a third-party server that is returning
-            # error responses we don't want Via 3 to return those same 4xx or
-            # 5xx status codes to the browser because this would mess up our
-            # monitoring and alerting. For example it might trigger an alarm
-            # that Via 3 is unhealthy because it's sending too many error
-            # responses.
-            # http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
-            error_page 404 410 = @proxy_not_found;
-            error_page 420 429 = @proxy_too_many_requests;
-            error_page 400 401 402 403 405 406 407 408 409 411 412 413 414 415 416 417 418 422 423 424 425 426 428 431 444 449 450 451 = @proxy_client_error;
-            error_page 500 501 502 503 504 505 506 507 508 509 510 511 598 599 = @proxy_upstream_error;
-
+            include includes/errors.conf;
             include includes/direct_proxy.conf;
+            include includes/cors.conf;
 
             # Cache for one day, but allow serving from cache while revalidating for a week.
             # https://web.dev/stale-while-revalidate/
@@ -105,13 +60,21 @@ http {
         }
 
         location @handle_redirect {
-            include includes/direct_proxy.conf;
+            include includes/errors.conf;
+            include includes/cors.conf;
 
-            # Don't cache redirect responses because they can be temporary
-            # redirects to PDF URLs that expire over time (the Canvas Files API
-            # does this, for example).
-            proxy_hide_header "Cache-Control";
-            add_header "Cache-Control" "no-cache, no-store, must-revalidate";
+            # Pass the server name through when connecting to proxied HTTPS servers.
+            # This is needed to make proxying of some sites work.
+            # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
+            proxy_ssl_server_name on;
+
+            # Just using $upstream_http_location in the proxy_pass below
+            # doesn't work. We have to save it into this variable first.
+            set $saved_redirect_location '$upstream_http_location';
+
+            # Follow the redirect internally, now proxying to the URL given in
+            # the redirect's Location header.
+            proxy_pass $saved_redirect_location;
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "static-proxy, redirect";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
       - GOOGLE_API_KEY
     volumes:
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./conf/nginx/includes/cors.conf:/etc/nginx/includes/cors.conf:ro
       - ./conf/nginx/includes/direct_proxy.conf:/etc/nginx/includes/direct_proxy.conf:ro
+      - ./conf/nginx/includes/errors.conf:/etc/nginx/includes/errors.conf:ro
       - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro
       - ./conf/nginx/includes.dev/app_upstream.conf:/etc/nginx/includes/app_upstream.conf:ro
       - ./conf/nginx/dev_host_bridge.sh:/etc/nginx/dev_host_bridge.sh:ro


### PR DESCRIPTION
When the third-party server that we're proxying responds with a 3xx redirect, on master we rewrite the redirect's `Location` header so that it begins with `https://via3.hypothes.is/proxy/static/` and return the rewritten redirect to the browser.

The problem with this is that in the future we want to use NGINX's secure links module to require `/proxy/static/` URLs to be signed. In the case of redirects that would mean that NGINX would have to sign the rewritten `Location` URL before sending it back to the browser, but NGINX's secure links module can only verify signatures, it can't sign things.

So this commit changes our NGINX to follow redirects internally instead of sending them back to the browser. When the third-party server that we're proxying responds with a 3xx NGINX will follow the redirect itself, downloading the file from the redirects `Location` header and returning it to the browser. 3xx's responses from third-party servers are "hidden" from browsers.

This works when the third-party server responds with:

* An absolute redirect

* A relative redirect

* A chain of multiple redirects (NGINX will follow each in turn)

* A too-long chain of redirects or an infinite cycle of redirects. After 10 redirects NGINX will stop and send a 500 back to the browser. (Unfortunately I don't think we can customize the status code of this response.)

* Redirect URLs with query params in them

* A redirect or chain of redirects where one of the `Location` URLs responds with an error. Our usual error handling kicks in where we hide the third-party error responses and status codes from the browser.