### PR TITLE
Remove unnecessary CORS header stripping

### DIFF
--- a/conf/nginx/includes/direct_proxy.conf
+++ b/conf/nginx/includes/direct_proxy.conf
@@ -31,10 +31,3 @@ proxy_pass $uri$is_args$args;
 # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
 proxy_redirect ~^(https?:\/\/)(.*)$ $original_scheme://$http_host/proxy/static/$1$2;
 proxy_redirect ~^(.*)$ $original_scheme://$http_host/proxy/static/https://$proxy_host$1;
-
-# Prevent the third party from adding CORS controls
-proxy_hide_header "Access-Control-Allow-Origin";
-proxy_hide_header "Access-Control-Allow-Credentials";
-proxy_hide_header "Access-Control-Allow-Methods";
-proxy_hide_header "Access-Control-Allow-Headers";
-proxy_hide_header "Access-Control-Expose-Headers";


### PR DESCRIPTION
I think these are completely unnecessary.

The reason why the LMS app has to use Via 3 is to get around CORS: the LMS app could just serve PDF.js itself and configure PDF.js's client-side JavaScript code to download the PDF from the third-party server directly. But many servers include CORS headers that tell the browser that JavaScript code from other origins should not be allowed to download the file. So when PDF.js JavaScript code from lms.hypothes.is tries to download a PDF from example.com, the browser blocks this due to CORS.

By serving both PDF.js and the PDF itself from via3.hypothes.is, the two are now on the same origin so CORS ("cross-origin") protections no longer apply.

It's *not* necessary to strip CORS headers from the third-party responses. The CORS-bypassing is based on making the PDF appear to come from the same origin by proxying it, not from stripping CORS headers.