### PR TITLE
Require nginx links to be signed

### DIFF
--- a/conf/nginx/envsubst.conf.template
+++ b/conf/nginx/envsubst.conf.template
@@ -3,3 +3,4 @@
 # ${FOO}'s in this file with values from environment variables.
 
 set $google_api_key "${GOOGLE_API_KEY}";
+set $nginx_secure_link_secret "${NGINX_SECURE_LINK_SECRET}";

--- a/conf/nginx/includes/direct_proxy.conf
+++ b/conf/nginx/includes/direct_proxy.conf
@@ -3,23 +3,61 @@
 # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
 proxy_ssl_server_name on;
 
-# Replace the default url-decoded $uri with the $request_uri which is as
-# we received it without url-decoding
-rewrite ^ $request_uri;
+# Rewrite drive.google.com URLs to googleapis.com ones that use our API key.
+#
+# This is because Google gives us a much higher rate limit / quota when we use
+# our API key.
+#
+# Notes:
+#
+# * If a `rewrite`'s replacement string starts with "http://", "https://" or
+#   "$scheme" nginx immediately stops processing after this rewrite rule and
+#   returns a redirect to the client. We don't want this to happen so we
+#   capture the "https" in the `rewrite`'s regex so that we can use it as "$1"
+#   in the replacement string!
+#
+# * If a `rewrite`'s replacement string contains query params nginx also
+#   appends the _previous_ query params (from the pre-rewrite $uri) after them.
+#   We don't want this. The `?` at the end of the replacement string disables it.
+#
+# * The `break` at the end causes nginx to skip any subsequent rewrite module
+#   directives (e.g. other `rewrite`'s). If the request matches this rewrite
+#   (i.e. it's an https://drive.google.com request) then this will be the
+#   *last* rewrite that gets processed for the request.
+#
+#   Subsequent non-rewrite module directives will still get processed.
+#
+#   The `break` also causes nginx to stop processing at the end of this
+#   `location { ... }` and send the `proxy_pass`'d response back to the
+#   browser, rather than re-starting its processing using the rewritten $uri to
+#   search for a matching `location { ... }` again.
+#
+# http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite
+# http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#break
+rewrite ^(https)://drive.google.com/uc\?id=(.*)&export=download$ $1://www.googleapis.com/drive/v3/files/$2?key=$google_api_key&alt=media? break;
 
-# Redirect Google Drive requests to the API using our key
-# Some weird things:
-# * A rule that starts with http will _immediately_ issue a proxy_redirect
-# * So we seemingly pointlessly capture (https) and replace it
-# * This way the _result_ starts with https, but the _rule_ doesn't and we can carry on
-# * NGINX will _merge_ queries you add, not replace them unless you put '?' on the end
-rewrite ^/proxy/static/(https)://drive.google.com/uc\?id=(.*)&export=download$ $1://www.googleapis.com/drive/v3/files/$2?key=$google_api_key&alt=media? break;
+# Remove the query params from the URI so we can add them back again later.
+#
+# If the request had matched the drive.google.com rewrite above its query
+# params would have been removed. If the request does *not* match the
+# drive.google.com rewrite then it will match this rewrite instead. We need to
+# strip the query params from non-drive.google.com requests as well so that we
+# can unconditionally re-add them in the proxy_pass below.
+#
+# The `break` is necessary to cause nginx to stop processing at the end of this
+# `location { ... }` and send the `proxy_pass`'d response back to the browser,
+# rather than re-starting its processing using the rewritten $uri to search for
+# a matching `location { ... }` again.
+#
+# http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite
+# http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#break
+rewrite ^(.*)$ $1? break;
 
-# Remove our URL part off of the front
-# The ? at the end means we strip off the args part (which we will add back on later)
-# I have no idea why this works to be honest but it seems to
-rewrite ^/proxy/static/(.*)$ $1? break;
-
-# The proxy directly to the resulting URL
-# Add back on the args which we stripped above so we don't get them twice
+# Proxy to the resulting $uri (after all the `rewrite`s above).
+#
+# Query params have been stripped from $uri so re-add them with $is_args$args.
+#
+# http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#var_is_args
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#var_args
 proxy_pass $uri$is_args$args;

--- a/conf/nginx/includes/secure_links.conf
+++ b/conf/nginx/includes/secure_links.conf
@@ -1,0 +1,47 @@
+# Require the request to be signed with an MD5 and expiration in the URL,
+# responding with an error if the request isn't signed.
+#
+# This uses nginx's built-in secure link module:
+#
+# https://www.nginx.com/blog/securing-urls-secure-link-module-nginx-plus/
+# http://nginx.org/en/docs/http/ngx_http_secure_link_module.html
+
+# Give nginx's secure link module the checksum ($sec) and expiration time
+# ($exp) to verify.
+#
+# $sec and $exp are extracted from the requested URI by the `location` regex in nginx.conf.
+#
+# http://nginx.org/en/docs/http/ngx_http_secure_link_module.html#secure_link
+secure_link $sec,$exp;
+
+# Replace the $uri variable (which is URL-decoded) with the raw version from $request_uri.
+# http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite
+rewrite ^ $request_uri;
+
+# Remove the /proxy/static/<SEC>/<EXP> prefix from the $uri, we don't need it anymore.
+# (And we do need easy access to $uri without the prefix because
+# that's the third-party URL that we need to proxy.)
+# http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite
+rewrite ^/proxy/static/[^/]+/[^/]+/(.*)$ $1;
+
+# The string that we expect the MD5 digest in the URL ($sec) to be a hash of:
+#
+#   $secure_link_expires is the timestamp in the URL (the same as $exp)
+#   $uri is the URL to be proxied
+#   $nginx_secure_link_secret comes from the NGINX_SECURE_LINK_SECRET environment variable
+#
+# http://nginx.org/en/docs/http/ngx_http_secure_link_module.html#secure_link_md5
+secure_link_md5 "/proxy/static/$secure_link_expires/$uri $nginx_secure_link_secret";
+
+# $secure_link will be set to:
+#
+#   "" if the MD5 digest in the URL ($sec) is missing or wrong
+#   "0" if the digest is valid but the timestamp in the URL ($exp) has expired
+#   "1" if both the digest and the timestamp are valid
+
+# If the MD5 digest is missing or invalid respond with a 403.
+if ($secure_link = "") { return 403; }
+
+# If the expiry time has passed respond with a 410.
+# (FIXME: This 410 gets converted into a 404 by our @proxy_not_found below.)
+if ($secure_link = "0") { return 410; }

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -42,9 +42,12 @@ http {
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#merge_slashes
         merge_slashes off;
 
-        location ~ /proxy/static/ {
+        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/ {
             # We don't want our URLs that proxy third-party pages to show in Google.
             include includes/robots.conf;
+
+            # Require /proxy/static requests to be signed.
+            include includes/secure_links.conf;
 
             include includes/errors.conf;
             include includes/direct_proxy.conf;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,16 @@ services:
       - '127.0.0.1:9083:9083'
     environment:
       - GOOGLE_API_KEY
+      - NGINX_SECURE_LINK_SECRET
     volumes:
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./conf/nginx/includes/cors.conf:/etc/nginx/includes/cors.conf:ro
       - ./conf/nginx/includes/direct_proxy.conf:/etc/nginx/includes/direct_proxy.conf:ro
       - ./conf/nginx/includes/errors.conf:/etc/nginx/includes/errors.conf:ro
       - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro
+      - ./conf/nginx/includes/secure_links.conf:/etc/nginx/includes/secure_links.conf:ro
       - ./conf/nginx/includes.dev/app_upstream.conf:/etc/nginx/includes/app_upstream.conf:ro
       - ./conf/nginx/dev_host_bridge.sh:/etc/nginx/dev_host_bridge.sh:ro
       - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template:ro
-    command: /bin/sh -c "/etc/nginx/dev_host_bridge.sh && envsubst '$${GOOGLE_API_KEY}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
+    command: /bin/sh -c "/etc/nginx/dev_host_bridge.sh && envsubst '$${GOOGLE_API_KEY}:$${NGINX_SECURE_LINK_SECRET}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -22,6 +22,7 @@ disable=bad-continuation,
         no-value-for-parameter,
         redefined-outer-name,
         too-few-public-methods,
+        too-many-arguments,
         unused-argument,
 
 [REPORTS]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def pyramid_settings():
         "via_html_url": "https://viahtml3.hypothes.is/proxy",
         "checkmate_url": "http://localhost:9099",
         "checkmate_enabled": True,
+        "nginx_secure_link_secret": "not_a_secret",
     }
 
 

--- a/tests/unit/via/app_test.py
+++ b/tests/unit/via/app_test.py
@@ -11,7 +11,7 @@ def test_settings_raise_value_error_if_environment_variable_is_not_set():
         load_settings({})
 
 
-def test_settings_are_configured_from_environment_variables(os_env, pyramid_settings):
+def test_settings_are_configured_from_environment_variables(os, pyramid_settings):
     expected_settings = pyramid_settings
 
     settings = load_settings({})
@@ -20,7 +20,7 @@ def test_settings_are_configured_from_environment_variables(os_env, pyramid_sett
         assert settings[key] == value
 
 
-def test_app(configurator, pyramid, os_env, pyramid_settings):
+def test_app(configurator, pyramid, os, pyramid_settings):
     create_app()
 
     expected_settings = dict(
@@ -47,10 +47,8 @@ def pyramid(patch):
 
 
 @pytest.fixture
-def os_env(patch, pyramid_settings):
-    def get(env_var):
-        return pyramid_settings[env_var.lower()]
-
-    os = patch("via.app.os")
-    os.environ.get = get
-    return os
+def os(patch, pyramid_settings):
+    return patch(
+        "via.app.os",
+        environ={key.upper(): value for key, value in pyramid_settings.items()},
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ setenv =
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: CHECKMATE_URL = http://localhost:9099
+    {dev,functests}: NGINX_SECURE_LINK_SECRET = not_a_secret
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 passenv =
     HOME

--- a/via/app.py
+++ b/via/app.py
@@ -32,6 +32,7 @@ def load_settings(settings):
     settings["h_pyramid_sentry.filters"] = SENTRY_FILTERS
 
     settings["checkmate_enabled"] = asbool(os.environ.get("CHECKMATE_ENABLED"))
+    settings["nginx_secure_link_secret"] = os.environ["NGINX_SECURE_LINK_SECRET"]
 
     return settings
 

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -1,7 +1,11 @@
 """View presenting the PDF viewer."""
+import hashlib
 import json
+from base64 import b64encode
+from datetime import timedelta
 
 from h_vialib import Configuration
+from h_vialib.secure import quantized_expiry
 from markupsafe import Markup
 from pyramid import view
 
@@ -20,18 +24,53 @@ def view_pdf(context, request):
     """HTML page with client and the PDF embedded."""
 
     nginx_server = request.registry.settings["nginx_server"]
-    pdf_url = f"{nginx_server}/proxy/static/{context.url()}"
+    pdf_url = _pdf_url(
+        context.url(),
+        nginx_server,
+        request.registry.settings["nginx_secure_link_secret"],
+    )
 
     _, h_config = Configuration.extract_from_params(request.params)
 
     return {
-        "pdf_url": _string_literal(pdf_url),
+        "pdf_url": pdf_url,
         "client_embed_url": _string_literal(
             request.registry.settings["client_embed_url"]
         ),
         "static_url": request.static_url,
         "hypothesis_config": h_config,
     }
+
+
+def _pdf_url(url, nginx_server, secret):
+    # Compute the expiry time to put into the URL.
+    exp = int(quantized_expiry(max_age=timedelta(hours=2)).timestamp())
+
+    # The expression to be hashed.
+    #
+    # This matches the hash expression that we tell the NGINX secure link
+    # module to use with the secure_link_md5 setting in our NGINX config file.
+    #
+    # http://nginx.org/en/docs/http/ngx_http_secure_link_module.html#secure_link_md5
+    hash_expression = f"/proxy/static/{exp}/{url} {secret}"
+
+    # Compute the hash value to put into the URL.
+    #
+    # This implements the NGINX secure link module's hashing algorithm:
+    #
+    # http://nginx.org/en/docs/http/ngx_http_secure_link_module.html#secure_link_md5
+    hash_ = hashlib.md5()
+    hash_.update(hash_expression.encode("utf-8"))
+    sec = hash_.digest()
+    sec = b64encode(sec)
+    sec = sec.replace(b"+", b"-")
+    sec = sec.replace(b"/", b"_")
+    sec = sec.replace(b"=", b"")
+    sec = sec.decode()
+
+    # Construct the URL, inserting sec and exp where our NGINX config file
+    # expects to find them.
+    return _string_literal(f"{nginx_server}/proxy/static/{sec}/{exp}/{url}")
 
 
 def _string_literal(string):


### PR DESCRIPTION
Depends on: [Follow redirects internally](https://github.com/hypothesis/via3/pull/349)

This PR:

1. Requires requests to `/proxy/static/` to be signed
2. Changes the `/pdf` route to sign the `/proxy/static/` URLs that it generates

This doesn't actually secure anything since the `/pdf` endpoint itself is still open and will generate a signed `/proxy/static` URL to any URL that you want.

## Testing

You need to run my test app for testing this: https://github.com/hypothesis/pdf_redriects (I think the typo in the name is probably appropriate). Then:

- [x] The localhost assignments (HTML, PDF, Canvas Files, Google Drive) in the [Sections Enabled](https://hypothesis.instructure.com/courses/125) test course should work

- [x] The **localhost (make devdata) Redirects Test Assignment** assignments in the same course should all work as expected (some of these are expected to crash)