### PR TITLE
Check for signed URLs in /pdf and /route

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ def pyramid_settings():
         "checkmate_url": "http://localhost:9099",
         "checkmate_enabled": True,
         "nginx_secure_link_secret": "not_a_secret",
+        "via_secret": "not_a_secret",
+        "signed_urls_required": True,
     }
 
 

--- a/tests/unit/via/views/decorators_test.py
+++ b/tests/unit/via/views/decorators_test.py
@@ -3,13 +3,19 @@ from unittest import mock
 import checkmatelib
 import pytest
 from checkmatelib import CheckmateException
+from h_vialib.exceptions import TokenException
 from pyramid.response import Response
 
-from via.views.decorators import checkmate_block
+from via.views.decorators import checkmate_block, has_secure_url_token
 
 
 @checkmate_block
-def dummy_view(context, request):
+def dummy_view_checkmate_block(context, request):
+    return Response("ok")
+
+
+@has_secure_url_token
+def dummy_view_url_token(context, request):
     return Response("ok")
 
 
@@ -20,7 +26,7 @@ class TestCheckMateBlockDecorator:
         mock_check_url.return_value = None
         request = make_request(params={"url": url})
 
-        response = dummy_view(None, request)
+        response = dummy_view_checkmate_block(None, request)
 
         mock_check_url.assert_called_once_with(url, allow_all=True)
         assert response.status_code == 200
@@ -32,7 +38,7 @@ class TestCheckMateBlockDecorator:
         request = make_request(params={"url": url})
         request.registry.settings["checkmate_enabled"] = False
 
-        response = dummy_view(None, request)
+        response = dummy_view_checkmate_block(None, request)
 
         mock_check_url.assert_not_called()
 
@@ -45,7 +51,7 @@ class TestCheckMateBlockDecorator:
         mock_check_url.return_value = block_response
         request = make_request(params={"url": url})
 
-        response = dummy_view(None, request)
+        response = dummy_view_checkmate_block(None, request)
 
         mock_check_url.assert_called_once_with(url, allow_all=True)
         assert response.status_code == 307
@@ -56,7 +62,7 @@ class TestCheckMateBlockDecorator:
         CheckmateClient.return_value.check_url.side_effect = CheckmateException()
         request = make_request(params={"url": url})
 
-        response = dummy_view(None, request)
+        response = dummy_view_checkmate_block(None, request)
 
         # Request continues despite Checkmate errors
         assert response.status_code == 200
@@ -71,3 +77,45 @@ class TestCheckMateBlockDecorator:
     @pytest.fixture
     def CheckmateClient(self, patch):
         return patch("via.views.decorators.CheckmateClient")
+
+
+class TestSignedURLDecorator:
+    def test_signed_urls_disabled(self, make_request, ViaSecureURL):
+        request = make_request()
+        request.registry.settings["signed_urls_required"] = False
+
+        response = dummy_view_url_token(None, request)
+
+        ViaSecureURL.assert_not_called()
+        assert response.status_code == 200
+        assert response.text == "ok"
+
+    def test_signed_urls_disabled_with_signature(self, make_request, ViaSecureURL):
+        request = make_request(params={"via.sec": "invalid"})
+        request.registry.settings["signed_urls_required"] = False
+        ViaSecureURL.return_value.verify.side_effect = TokenException()
+
+        response = dummy_view_url_token(None, request)
+
+        assert response.status_code == 401
+
+    def test_invalid_token(self, make_request, ViaSecureURL):
+        ViaSecureURL.return_value.verify.side_effect = TokenException()
+        request = make_request(params={"via.sec": "invalid"})
+
+        response = dummy_view_url_token(None, request)
+
+        assert response.status_code == 401
+
+    def test_valid_token(self, make_request, ViaSecureURL):
+        ViaSecureURL.return_value.verify.return_value = "secure"
+        request = make_request(params={"via.sec": "secure"})
+
+        response = dummy_view_url_token(None, request)
+
+        assert response.status_code == 200
+        assert response.text == "ok"
+
+    @pytest.fixture
+    def ViaSecureURL(self, patch):
+        return patch("via.views.decorators.ViaSecureURL")

--- a/tests/unit/via/views/route_by_content/view_test.py
+++ b/tests/unit/via/views/route_by_content/view_test.py
@@ -44,7 +44,9 @@ class TestRouteByContent:
         url = "http://example.com/path%2C?a=b"
         results = call_route_by_content(url, params={"other": "value"})
 
-        assert results.location == Any.url.with_query({"other": "value", "url": url})
+        assert results.location == Any.url.with_query(
+            {"other": "value", "url": url, "via.sec": Any.string()}
+        )
 
     @pytest.mark.usefixtures("html_response")
     def test_html_payloads_are_handled_by_the_html_rewriter_service(

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: CHECKMATE_URL = http://localhost:9099
     {dev,functests}: NGINX_SECURE_LINK_SECRET = not_a_secret
+    dev: VIA_SECRET = not_a_secret
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 passenv =
     HOME

--- a/via/app.py
+++ b/via/app.py
@@ -9,7 +9,13 @@ from whitenoise import WhiteNoise
 from via.cache_buster import PathCacheBuster
 from via.sentry_filters import SENTRY_FILTERS
 
-REQUIRED_PARAMS = ["client_embed_url", "nginx_server", "via_html_url", "checkmate_url"]
+REQUIRED_PARAMS = [
+    "client_embed_url",
+    "nginx_server",
+    "via_html_url",
+    "checkmate_url",
+    "via_secret",
+]
 
 
 def load_settings(settings):
@@ -32,6 +38,7 @@ def load_settings(settings):
     settings["h_pyramid_sentry.filters"] = SENTRY_FILTERS
 
     settings["checkmate_enabled"] = asbool(os.environ.get("CHECKMATE_ENABLED"))
+    settings["signed_urls_required"] = asbool(os.environ.get("SIGNED_URLS_REQUIRED"))
     settings["nginx_secure_link_secret"] = os.environ["NGINX_SECURE_LINK_SECRET"]
 
     return settings

--- a/via/views/decorators.py
+++ b/via/views/decorators.py
@@ -2,7 +2,9 @@
 import logging
 
 from checkmatelib import CheckmateClient, CheckmateException
-from pyramid.httpexceptions import HTTPTemporaryRedirect
+from h_vialib.exceptions import TokenException
+from h_vialib.secure.url import ViaSecureURL
+from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPUnauthorized
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +33,25 @@ def checkmate_block(view, url_param="url", allow_all=True):
 
         if blocked:
             return HTTPTemporaryRedirect(location=blocked.presentation_url)
+
+        return view(context, request)
+
+    return view_wrapper
+
+
+def has_secure_url_token(view, signature_param="via.sec"):
+    """Require the request to have a valid signature in the "via.sec" query param."""
+
+    def view_wrapper(context, request):
+        signature = request.params.get(signature_param)
+        if not signature and not request.registry.settings["signed_urls_required"]:
+            return view(context, request)
+
+        secure_token = ViaSecureURL(request.registry.settings["via_secret"])
+        try:
+            secure_token.verify(request.url)
+        except TokenException:
+            return HTTPUnauthorized()
 
         return view(context, request)
 

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -9,7 +9,7 @@ from h_vialib.secure import quantized_expiry
 from markupsafe import Markup
 from pyramid import view
 
-from via.views.decorators import checkmate_block
+from via.views.decorators import checkmate_block, has_secure_url_token
 
 
 @view.view_config(
@@ -18,7 +18,7 @@ from via.views.decorators import checkmate_block
     # We have to keep the leash short here for caching so we can pick up new
     # immutable assets when they are deployed
     http_cache=0,
-    decorator=checkmate_block,
+    decorator=(checkmate_block, has_secure_url_token),
 )
 def view_pdf(context, request):
     """HTML page with client and the PDF embedded."""


### PR DESCRIPTION
To quickly check locally:

- LMS in master branch
- via3 in this branch

`https://hypothesis.instructure.com/courses/125/assignments/874` should load

Change VIA_SECRET in either LMS or via3 to no longer match each other (and `make dev` again)

`https://hypothesis.instructure.com/courses/125/assignments/874` should return a 401

