### PR TITLE
Fix botched upgrade of h-vialib

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,7 +22,7 @@ future==0.18.2            # via -r requirements/requirements.txt, h-checkmatelib
 gunicorn==20.0.4          # via -r requirements/requirements.txt
 h-checkmatelib==1.0.3     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
-h-vialib==1.0.1           # via -r requirements/requirements.txt
+h-vialib==1.0.3           # via -r requirements/requirements.txt
 hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
 idna==2.10                # via -r requirements/requirements.txt, requests
 importlib-metadata==3.4.0  # via -r requirements/requirements.txt, jsonschema
@@ -45,6 +45,7 @@ prompt-toolkit==3.0.14    # via ipython
 ptyprocess==0.7.0         # via pexpect
 pycparser==2.20           # via cffi
 pygments==2.7.4           # via ipython
+pyjwt==2.0.1              # via -r requirements/requirements.txt, h-vialib
 pynacl==1.4.0             # via paramiko
 pyramid-ipython==0.2      # via -r requirements/dev.in
 pyramid-jinja2==2.8       # via -r requirements/requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -13,7 +13,7 @@ gunicorn==20.0.4          # via -r requirements/requirements.txt
 h-checkmatelib==1.0.3     # via -r requirements/requirements.txt
 h-matchers==1.2.10        # via -r requirements/functests.in
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
-h-vialib==1.0.1           # via -r requirements/requirements.txt
+h-vialib==1.0.3           # via -r requirements/requirements.txt
 httpretty==1.0.5          # via -r requirements/functests.in
 hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
 idna==2.10                # via -r requirements/requirements.txt, requests
@@ -29,6 +29,7 @@ plaster-pastedeploy==0.7  # via -r requirements/requirements.txt, pyramid
 plaster==1.0              # via -r requirements/requirements.txt, plaster-pastedeploy, pyramid
 pluggy==0.13.1            # via pytest
 py==1.10.0                # via pytest
+pyjwt==2.0.1              # via -r requirements/requirements.txt, h-vialib
 pyparsing==2.4.7          # via packaging
 pyramid-jinja2==2.8       # via -r requirements/requirements.txt
 pyramid==1.10.5           # via -r requirements/requirements.txt, h-pyramid-sentry, pyramid-jinja2

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -17,7 +17,7 @@ gunicorn==20.0.4          # via -r requirements/requirements.txt, -r requirement
 h-checkmatelib==1.0.3     # via -r requirements/requirements.txt, -r requirements/tests.txt
 h-matchers==1.2.10        # via -r requirements/tests.txt
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt, -r requirements/tests.txt
-h-vialib==1.0.1           # via -r requirements/requirements.txt, -r requirements/tests.txt
+h-vialib==1.0.3           # via -r requirements/requirements.txt, -r requirements/tests.txt
 htmlmin==0.1.12           # via -r requirements/lint.in
 httpretty==1.0.5          # via -r requirements/tests.txt
 hupper==1.10.2            # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
@@ -38,6 +38,7 @@ plaster==1.0              # via -r requirements/requirements.txt, -r requirement
 pluggy==0.13.1            # via -r requirements/tests.txt, pytest
 py==1.10.0                # via -r requirements/tests.txt, pytest
 pydocstyle==5.1.1         # via -r requirements/lint.in
+pyjwt==2.0.1              # via -r requirements/requirements.txt, -r requirements/tests.txt, h-vialib
 pylint==2.6.0             # via -r requirements/lint.in
 pyparsing==2.4.7          # via -r requirements/tests.txt, packaging
 pyramid-jinja2==2.8       # via -r requirements/requirements.txt, -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,7 +11,7 @@ future==0.18.2            # via h-checkmatelib
 gunicorn==20.0.4          # via -r requirements/requirements.in
 h-checkmatelib==1.0.3     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.in
-h-vialib===1.0.3          # via -r requirements/requirements.in
+h-vialib==1.0.3           # via -r requirements/requirements.in
 hupper==1.10.2            # via pyramid
 idna==2.10                # via requests
 importlib-metadata==3.4.0  # via jsonschema

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -16,7 +16,7 @@ gunicorn==20.0.4          # via -r requirements/requirements.txt
 h-checkmatelib==1.0.3     # via -r requirements/requirements.txt
 h-matchers==1.2.10        # via -r requirements/tests.in
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
-h-vialib==1.0.1           # via -r requirements/requirements.txt
+h-vialib==1.0.3           # via -r requirements/requirements.txt
 httpretty==1.0.5          # via -r requirements/tests.in
 hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
 idna==2.10                # via -r requirements/requirements.txt, requests
@@ -32,6 +32,7 @@ plaster-pastedeploy==0.7  # via -r requirements/requirements.txt, pyramid
 plaster==1.0              # via -r requirements/requirements.txt, plaster-pastedeploy, pyramid
 pluggy==0.13.1            # via pytest
 py==1.10.0                # via pytest
+pyjwt==2.0.1              # via -r requirements/requirements.txt, h-vialib
 pyparsing==2.4.7          # via packaging
 pyramid-jinja2==2.8       # via -r requirements/requirements.txt
 pyramid==1.10.5           # via -r requirements/requirements.txt, h-pyramid-sentry, pyramid-jinja2


### PR DESCRIPTION
Forgot to run `make requirements` when doing this PR:
https://github.com/hypothesis/via3/pull/359