### PR TITLE
Remove unnecessary CORS header stripping

### DIFF
--- a/conf/nginx/includes/cors.conf
+++ b/conf/nginx/includes/cors.conf
@@ -1,7 +1,0 @@
-# Prevent third-party servers from adding CORS controls.
-
-proxy_hide_header "Access-Control-Allow-Origin";
-proxy_hide_header "Access-Control-Allow-Credentials";
-proxy_hide_header "Access-Control-Allow-Methods";
-proxy_hide_header "Access-Control-Allow-Headers";
-proxy_hide_header "Access-Control-Expose-Headers";

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -47,7 +47,6 @@ http {
 
             include includes/errors.conf;
             include includes/direct_proxy.conf;
-            include includes/cors.conf;
 
             # Cache for one day, but allow serving from cache while revalidating for a week.
             # https://web.dev/stale-while-revalidate/
@@ -60,7 +59,6 @@ http {
 
         location @handle_redirect {
             include includes/errors.conf;
-            include includes/cors.conf;
 
             # Pass the server name through when connecting to proxied HTTPS servers.
             # This is needed to make proxying of some sites work.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - NGINX_SECURE_LINK_SECRET
     volumes:
       - ./conf/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./conf/nginx/includes/cors.conf:/etc/nginx/includes/cors.conf:ro
       - ./conf/nginx/includes/direct_proxy.conf:/etc/nginx/includes/direct_proxy.conf:ro
       - ./conf/nginx/includes/errors.conf:/etc/nginx/includes/errors.conf:ro
       - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro


### PR DESCRIPTION
I think these are completely unnecessary.

The reason why the LMS app has to use Via 3 is to get around CORS: the
LMS app could just serve PDF.js itself and configure PDF.js's
client-side JavaScript code to download the PDF from the third-party
server directly. But many servers include CORS headers that tell the
browser that JavaScript code from other origins should not be allowed to
download the file. So when PDF.js JavaScript code from lms.hypothes.is
tries to download a PDF from example.com, the browser blocks this due to
CORS.

By serving both PDF.js and the PDF itself from via3.hypothes.is, the two
are now on the same origin so CORS ("cross-origin") protections no
longer apply.

It's not necessary to strip CORS headers from the third-party responses.
The CORS-bypassing is based on making the PDF appear to come from the
same origin by proxying it, not from stripping CORS headers.