### PR TITLE
Revert "Use nginx's default pidfile location"

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,6 +1,11 @@
 # Tell nginx not to daemonize (background) itself: http://nginx.org/en/docs/ngx_core_module.html#daemon
 daemon off;
 
+# Change the location of the file that stores nginx's process ID: http://nginx.org/en/docs/ngx_core_module.html#pid
+# nginx crashes if you don't do this, looks like maybe the default pidfile
+# directory doesn't exist.
+pid /var/lib/hypothesis/nginx.pid;
+
 # Log errors to stderr: http://nginx.org/en/docs/ngx_core_module.html#error_log
 error_log /dev/stderr;
 


### PR DESCRIPTION
Reverts hypothesis/via3#341. This broke QA: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1613401089168500

```
nginx (stderr)       | 2021/02/15 12:23:10 [emerg] 30#30: open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
nginx (stderr)       | nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
2021-02-15 12:23:10,399 INFO exited: nginx (exit status 1; not expected)
web                  | Cache buster salt: 572f3864d15d2fcbda500df796a5514d
web                  | Cache buster salt: 572f3864d15d2fcbda500df796a5514d
web                  | Cache buster salt: 572f3864d15d2fcbda500df796a5514d
2021-02-15 12:23:12,455 INFO spawned: 'nginx' with pid 31
nginx (stderr)       | 2021/02/15 12:23:12 [emerg] 31#31: open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
nginx (stderr)       | nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
2021-02-15 12:23:12,483 INFO exited: nginx (exit status 1; not expected)
2021-02-15 12:23:15,488 INFO spawned: 'nginx' with pid 32
nginx (stderr)       | 2021/02/15 12:23:15 [emerg] 32#32: open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
nginx (stderr)       | nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
2021-02-15 12:23:15,522 INFO exited: nginx (exit status 1; not expected)
2021-02-15 12:23:16,524 INFO gave up: nginx entered FATAL state, too many start retries too quickly
```