### PR TITLE
Add a couple of explanatory comments to nginx.conf

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -47,9 +47,20 @@ http {
             include includes/robots.conf;
 
             # Require /proxy/static requests to be signed.
+            #
+            # Note: this modifies NGINX's $uri variable!
+            # It replaces the default URL-decoded value of $uri with a raw
+            # version, and also strips the leading /proxy/static/<SEC>/<EXP>/
+            # off the front.
             include includes/secure_links.conf;
 
             include includes/errors.conf;
+
+            # Proxy to the URL given in the request path (/proxy/static/<SEC>/<EXP>/<URL>).
+            #
+            # Note: proxy.conf expects the leading /proxy/static/<SEC>/<EXP>/
+            # to have already been stripped from $uri by secure_links.conf
+            # above!
             include includes/proxy.conf;
 
             # Cache for one day, but allow serving from cache while revalidating for a week.


### PR DESCRIPTION
`proxy.conf` has an explicit dependency on modifications that `secure_links.conf` makes to `$uri`. They both have to be included, and in the right order. Pretty confusing.

Rather than try to refactor the NGINX config files to be less confusing, to save time I've just added a couple of quick comments to flag this.