### PR TITLE
Fix handling of relative redirects in NGINX

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -42,7 +42,29 @@ http {
         # http://nginx.org/en/docs/http/ngx_http_core_module.html#merge_slashes
         merge_slashes off;
 
-        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/ {
+        # This `location` matches request paths like:
+        #
+        #     /proxy/static/<sec>/<exp>/<proxy_scheme>/<proxy_hostname><proxy_path>
+        #
+        # For example:
+        #
+        #     /proxy/static/abc123/456def/https://foo.example.com/bar/gar.pdf
+        #
+        # The following variables are extracted from the request path for later use:
+        #
+        # ?sec: The checksum for the NGINX secure link module (see includes/secure_links.conf),
+        # e.g. "abc123"
+        #
+        # ?exp: The timestamp for the NGINX secure link module (see includes/secure_links.conf)
+        # e.g. "456def"
+        #
+        # ?proxy_scheme: The scheme part of the URL-to-be-proxied, "http://" or "https://"
+        #
+        # ?proxy_hostname: The hostname part of the URL-to-be-proxied, e.g. "foo.example.com"
+        # Not to be confused with NGINX's builtin $proxy_host variable!
+        #
+        # ?proxy_path: The path part of the URL-to-be-proxied, e.g. "/bar/gar.pdf"
+        location ~ ^/proxy/static/(?<sec>[a-zA-Z0-9-_]+)/(?<exp>\d+)/(?<proxy_scheme>https?://)(?<proxy_hostname>[^/]+)(?<proxy_path>.*) {
             # We don't want our URLs that proxy third-party pages to show in Google.
             include includes/robots.conf;
 
@@ -69,9 +91,35 @@ http {
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
             proxy_ssl_server_name on;
 
-            # Just using $upstream_http_location in the proxy_pass below
-            # doesn't work. We have to save it into this variable first.
-            set $saved_redirect_location '$upstream_http_location';
+            # If we received an absolute redirect from the third-party server
+            # ($upstream_http_location begins with "http://" or "https://")
+            # then we can follow that redirect location directly.
+            #
+            # If we received a *relative* redirect ($upstream_http_location
+            # does *not* begin with "http://" or "https://") then we need to
+            # turn the relative redirect into an absolute one before following
+            # it.
+            #
+            # http://nginx.org/en/docs/http/ngx_http_upstream_module.html#var_upstream_http_
+            #
+            # Note that we're using NGINX's `if` in a `location` context here,
+            # which is said to be evil. But it seems to work, and I don't know
+            # of any other way to handle both absolute and relative redirects
+            # together.
+            #
+            # http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#if
+            # https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
+            #
+            # The "~*" triggers case-insensitive regex matching.
+            if ($upstream_http_location ~* "^https?://.*") {
+                set $saved_redirect_location '$upstream_http_location';
+            }
+            # "!~*" triggers *negative* case-insensitive regex matching. The
+            # `if` will match if $upstream_http_location does *not* match the
+            # given regex.
+            if ($upstream_http_location !~* "^https?://.*") {
+                set $saved_redirect_location '$proxy_scheme$proxy_hostname$upstream_http_location';
+            }
 
             # Follow the redirect internally, now proxying to the URL given in
             # the redirect's Location header.


### PR DESCRIPTION
Handle PDF hosts that return relative redirects, such as Box.com.

I thought this was working but it turns out that the test app I had used to generate relative redirects to PDF files was actually returning absolute ones! Relative redirects were not working.

Box.com is an example of a PDF host whose PDF download URLs return chains of three redirects where the first redirect's `Location` header contains a relative URL and the subsequent redirects have absolute `Location`'s. This commit fixes Via 3 with these Box.com URLs.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1614112183073900

Testing:

I've created a [localhost (make devdata) Box.com PDF Assignment](https://hypothesis.instructure.com/courses/125/assignments/1504) that doesn't work on master, but does work on this branch.

It's also worth testing all the other localhost assignments in Canvas, and running the [pdf_redirects](https://github.com/hypothesis/pdf_redriects) app and testing the localhost PDF redirects assignments.