### PR TITLE
Keep blocked_for param when checkmate is disabled

### DIFF
--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -47,6 +47,22 @@ class TestRouteByContent:
 
         get_url_details.assert_called_once_with(url, Any.instance_of(EnvironHeaders))
 
+    def test_blocked_for_passed_to_viahtml(
+        self, call_route_by_content, via_client_service, get_url_details
+    ):
+        get_url_details.return_value = ("html", 200)
+        url = "http://example.com/path%2C?a=b"
+
+        call_route_by_content(
+            url,
+            params={"via.blocked_for": "lms"},
+            settings={"checkmate_enabled": False},
+        )
+
+        via_client_service.url_for.assert_called_once_with(
+            url, content_type="html", options={"via.blocked_for": "lms"}
+        )
+
     @pytest.mark.parametrize(
         "content_type,max_age", [("application/pdf", 300), ("text/html", 60)]
     )
@@ -83,8 +99,14 @@ class TestRouteByContent:
 
     @pytest.fixture
     def call_route_by_content(self, make_request):
-        def call_route_by_content(target_url="http://example.com", params=None):
+        def call_route_by_content(
+            target_url="http://example.com", params=None, settings=None
+        ):
             request = make_request(params=dict(params or {}, url=target_url))
+            if settings:
+
+                for key, value in settings.items():
+                    request.registry.settings[key] = value
             context = URLResource(request)
 
             return route_by_content(context, request)

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -28,8 +28,9 @@ def route_by_content(context, request):
     # should be passed on
     options = dict(request.params)
     options.pop("url")
-    # Checkmate check already done, no need to keep passing this
-    options.pop("via.blocked_for", None)
+    if request.registry.settings["checkmate_enabled"]:
+        # Checkmate check already done, no need to keep passing this
+        options.pop("via.blocked_for", None)
 
     via_client = request.find_service(ViaClientService)
     url = via_client.url_for(context.url(), content_type=content_type, options=options)


### PR DESCRIPTION
If checkmate check is disabled in via3 the blocked_for parameter needs to be passed to viahtml so it can make it to checkmate on the check viahtml does.

