### PR TITLE
Public Via proof-of-concept

### DIFF
--- a/via/templates/foo.html.jinja2
+++ b/via/templates/foo.html.jinja2
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Via</title>
+  </head>
+  <body style="margin:0;">
+    <iframe style="position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999" src={{ src }}></iframe>
+  </body>
+</html>

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -1,4 +1,6 @@
 """The views for the Pyramid app."""
+from pyramid.view import view_config
+
 from via.resources import URLResource
 
 
@@ -8,9 +10,15 @@ def add_routes(config):
     config.add_route("view_pdf", "/pdf", factory=URLResource)
     config.add_route("route_by_content", "/route", factory=URLResource)
     config.add_route("debug_headers", "/debug/headers")
+    config.add_route("foo", "/{fizzle:.*}")
 
 
 def includeme(config):
     """Pyramid config."""
     add_routes(config)
     config.scan(__name__)
+
+
+@view_config(route_name="foo", renderer="via:templates/foo.html.jinja2")
+def foo(request):
+    return {"src": request.route_url("route_by_content", _query={"url": request.path[1:]})}


### PR DESCRIPTION
This is extremely rough (it's literally five minutes work) but this is a proof-of-concept for one way that we might implement a new public Via based on Via 3 + Via HTML:

* It adds a new endpoint to Via 3 that accepts legacy Via-style URLs like `https://via.hypothes.is/https://example.com/foo.pdf`
* The view for that endpoint renders an HTML page containing a full-screen `<iframe>` whose `src` is a Via 3-style URL: `https://via.hypothes.is/route?url=https%3A%2F%2Fexample.com%2F`

Some Slack discussion of this proposal here: <https://hypothes-is.slack.com/archives/C4K6M7P5E/p1614873170461000>. I've included the pros / cons / consequences / questions raised by that Slack thread below.

## Advantages

* It's largely a proven solution: the LMS app runs Via 3 and Via HTML in an iframe, injecting an iframe with a Via 3 URL and then lets Via 3 redirect that iframe's location to its different sub-components as necessary, with all the redirecting and component URLs being hidden from the user because it's in an iframe (not in the location bar). This solution proposes to add a new view to Via 3 itself that does the same thing with an iframe that the LMS app currently does

* It hides the implementation details of Via 3 from the user / from the location bar (the fact that Via 3 is implemented as separate routing, PDF, and HTML components that run at separate paths or subdomains and redirect between each other). This means we can continue to evolve these implementation details, for example by moving the PDF proxying component to a separate app on a separate domain, or by experimentally replacing the HTML component with a different one running on a different domain, all behind the scenes

* It should be relatively quick and easy to implement. This could turn what we were expecting to be a multi-month project into just a sprint or two:
  * Doesn't require any changes to the existing Via 3 or Via HTML code. It just requires _adding_ a new view to Via 3
  * Doesn't require any changes to the LMS app. LMS injects the ugly `https://via.hypothes.is/route?url=...` (which then redirects to either `/pdf` or to Via HTML) and `https://via.hypothes.is/pdf?url=...` URLs, but the ugliness doesn't matter in LMS's case because it's not in the location bar. Nothing needs to change, LMS can continue doing this
  * Doesn't require Via 3 and Via HTML to be run under a single sub-domain. Via HTML can run on a separate domain. The user won't see that in the location bar (although see the discussion of third-party cookies under **Disadvantages** below)
  * Doesn't require Via 3 and Via HTML to be merged into a single GitHub repo, they can remain two separate projects
  * Doesn't require Via 3 and Via HTML to run on a single application server, they can remain on separate and differently-provisioned servers
  * Doesn't require any ops changes. For example we won't need to extend our deployment scripts to be able to handle deploying two apps from a single GitHub repo

* Supports legacy Via URLs
  * Legacy Via URLs in the wild will continue working
  * Also, going forward, **new** public URLs will be in the legacy Via style. We'll continue to use the more readable `https://via.hypothes.is/https://example.com/` URLs instead of the longer and uglier `https://via.hypothes.is/route?url=https%3A%2F%2Fexample.com%2F` ones. URLs are part of public Via's interface, both because they appear in the location bar and because users can copy them from the location bar and share them, so we want them to be nice.
  * Like with legacy Via the user visits a nice `https://via.hypothes.is/https://example.com` URL and, after everything has been rendered and the user is looking at the HTML or PDF, the URL in their location bar is **still** the nice `https://via.hypothes.is/https://example.com`. The URL in the location bar doesn't change (e.g. it doesn't redirect you to some uglier URL or sub-path). This means the nice URLs remain in the location bar, so whenever the user copies the URL from the location bar and shares it they're copying the nice URL. And it means we don't create a proliferation of multiple different Via URLs for proxying a given URL and then have to maintain backwards-compatibility for them all (or decide to break them)
  * The file type (PDF or HTML) isn't encoded in the URL, so nothing will go wrong if a given URL returns a PDF one day and HTML the next, or a PDF for me and HTML for you, etc.
 
* Within the iframe the origin of the iframe's src and the origins used by all resource links etc in the page match, which avoids a same-origin request becoming a cross-origin request

* It avoids doing anything more in NGINX than we currently do which, if our experience with doing things in NGINX so far is anything to go by, is probably a good thing

* Might make it easier to put our own Chrome above, below and around the page we're proxying because we can put that chrome outside of the iframe. E.g. a banner

* Because it doesn't change the top-level URL design we can switch public Via over to this new Via just by making a CNAME change and then, if it doesn't work, we can switch it back to legacy Via just by changing the CNAME back

* It can hide Checkmate URLs from the user. When Via 3 or Via HTML redirects to a Checkmate block page it's the iframe that's being redirected so the `https://checkmate.hypothes.is/ui/block?*` URL won't be exposed to the user in the location bar. This is nice because it avoids exposing a long and ugly URL to the user, avoids exposing an implementation detail (Checkmate) to the user, and avoids the top-level URL changing when a page is blocked (so for example if the page becomes unblocked and the user re-loads the same URL it will now work, rather than them just reloading a Checkmate block page directly).

  Basically for the same reason that it's nice to hide the internal details of Via 3 and Via HTML and their different URLs, domains and redirects from the location bar, it's also nice to hide the internal detail that is Checkmate.

  We previously agreed that exposing Checkmate URLs wasn't a big deal (see <https://github.com/hypothesis/checkmate/issues/181>) but I still think it's a nice-to-have and this solution gives us it for free

## Disadvantages

* It creates an extra network round trip. The browser first has to send a request to `via.hypothes.is/<URL>`. That responds with an HTML page containing an iframe that causes the browser to send another request to `via.hypothes.is/route?url=<URL>` which responds with a redirect to either `via.hypothes.is/pdf?url=<URL>` or `viahtml.hypothes.is/proxy/<URL>`. Only then does the PDF or HTML page finally start proxying. But:

  I don't think this needs to involve any extra network round-trips compared to Via 3 & Via HTML as they're currently used by the LMS app: the view for the `via.hypothes.is/<URL>` can check whether the URL is HTML or PDF and inject the `via.hypothes.is/pdf?url=<URL>` or `viahtml.hypothes.is/proxy/<URL>` URL directly instead of the `via.hypothes.is/route?url=<URL>` one, which would result in the same overall number of network round-trips as are currently made in LMS's Via.

  It _does_ introduce one extra network round-trip compared to legacy Via which just proxies the page directly at the original `via.hypothes.is/<URL>` URL. But the LMS app has also been doing that and has been fine.

  The initial `via.hypothes.is/<URL>` request only responds with a small HTML file so it likely wouldn't slow things down much anyway.

* Cookies set by the sites being proxied will be considered third-party cookies (because the top-level domain will be `via.hypothes.is` whereas the iframe's domain will be `viahtml.hypothes.is`) and will be blocked by some browsers, which may cause breakage to the sites being proxied. But:
  *  We did a large amount of testing of sites in Via HTML in LMS with third-party cookies blocked, and all the sites we tested seemed to work fine
  * Not all browsers block third-party cookies. Currently I believe Safari does by default. Chrome and Firefox _can_ block third-party cookies with non-default settings. Don't know about Edge and other browsers. Over time more browsers may move towards blocking third-party cookies by default
  * @robertknight says that legacy Via currently blocks all third-party cookies, so sites won't be any more broken than they currently are in legacy Via. @jon-betts disagrees that legacy Via blocks third-party cookies. It may be that legacy Via blocks the `Set-Cookie` header but not `document.cookie`. Hasn't been confirmed either way.
  * The LMS app already runs Via HTML in an iframe, so sites won't be any more broken that they currently are in LMS
  * We may be able to fix this by serving Via HTML on a sub-_path_ of the same subdomain as Via 3. Cloudflare page rules were suggested as one possible way to implement this. We could defer this third-party cookies fix until later rather than requiring it for v1.
    * A third-party cookies fix by serving Via HTML on the same subdomain might also fix third-party cookies in LMS when assignments are launched in a new tab. When LMS assignments are launched in an iframe there's nothing we can do about the cookies being considered third-party: the top-level frame's domain is that of the LMS. But teachers can also configure assignments to launch in a new tab, some LMS's (e.g. Blackboard) do this by default. Even when an assignment is not configured to launch in a new tab, we could show a <kbd>Launch in new tab</kbd> button at the top of our iframe. When launched in a new tab the top-level domain is `lms.hypothes.is` and the Via HTML iframe is `viahtml3.hypothes.is`. If we could run Via HTML at a sub-path of `lms.hypothes.is` then the cookies would be first-party

* If the iframe is navigated the URL in the location bar won't change.

  Navigation by clicking on links is currently disabled in Via, but this downside could come into play if we ever want to re-enable browsing within Via. It will also come into play currently if the page is navigated by means that we haven't prevented (even though we probably want to prevent them) such as JavaScript, form submissions etc. It will also come into play currently if the page is navigated by means that we **don't** want to prevent, e.g. redirects.

  It's not 100% clear that we actually _want_ the location bar's URL to change when the page is navigated. What are the pros and cons of this? But that is what legacy Via currently does.

  This problem can probably be mitigated with a probably small amount of JavaScript to monitor the iframe's URL and push new URLs onto the location bar whenever it changes. Some discussion of that here: <https://hypothes-is.slack.com/archives/C4K6M7P5E/p1614946058499100>

## Questions

* Can the fullscreen iframe work reliably in all browsers, including on mobile? It must fill the entire viewport, expand with the size of the page being proxied, and not create any scrolling issues or nested scrollbars etc.