### PR TITLE
Nginx - Update resolver value in nginx.conf

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -22,8 +22,7 @@ events {
 http {
     # Configure the DNS that nginx uses to connect to the servers it's proxying.
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
-    # TODO: Do we need to change this? Why have we chosen this value?
-    resolver 8.8.8.8 ipv6=off;
+    resolver 127.0.0.11 ipv6=off;
 
     # Log accesses to stdout: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
     access_log /dev/stdout;


### PR DESCRIPTION
This commit updates the resolver we are using inside nginx.conf to 127.0.0.11 which is the value of the resolver provider by the Docker container.

For more information there is an internal slack thread discussing this change: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1616415118027100