### PR TITLE
Nginx - Revert nginx.conf resolver value

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -22,7 +22,8 @@ events {
 http {
     # Configure the DNS that nginx uses to connect to the servers it's proxying.
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
-    resolver 127.0.0.11 ipv6=off;
+    # TODO: Do we need to change this? Why have we chosen this value?
+    resolver 8.8.8.8 ipv6=off;
 
     # Log accesses to stdout: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
     access_log /dev/stdout;


### PR DESCRIPTION
This commit rolls back the previous change made to the value of the resolver in nginx.conf. Here is a link to the previous PR for reference: https://github.com/hypothesis/via3/pull/416