### PR TITLE
nginx - update nginx.conf resolver parameter

### DIFF
--- a/conf/nginx/includes.dev/resolver.conf
+++ b/conf/nginx/includes.dev/resolver.conf
@@ -1,0 +1,3 @@
+# Use Cloudflare DNS (https://1.1.1.1/dns/) to resolve locally as the AWS
+# resolver is not available
+resolver 1.1.1.1 ipv6=off;

--- a/conf/nginx/includes/resolver.conf
+++ b/conf/nginx/includes/resolver.conf
@@ -1,0 +1,9 @@
+# Configure the DNS that nginx uses to connect to the servers it's proxying.
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
+# Here we are setting the value of the resolver to the AWS VPC DNS server.
+# Each AWS VPC has a DNS server available at the CIDR base + 2 address.
+# 169.254.169.253 is mapped to what ever that value is meaning we can deploy
+# in other AWS VPCs without updating the resolver value. The only requirement
+# is to have DNS support enabled for the VPC.
+
+resolver 169.254.169.253 ipv6=off;

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -22,8 +22,12 @@ events {
 http {
     # Configure the DNS that nginx uses to connect to the servers it's proxying.
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
-    # TODO: Do we need to change this? Why have we chosen this value?
-    resolver 8.8.8.8 ipv6=off;
+    # Here we are setting the value of the resolver to the AWS VPC DNS server.
+    # Each AWS VPC has a DNS server available at the CIDR base + 2 address.
+    # 169.254.169.253 is mapped to what ever that value is meaning we can deploy
+    # in other AWS VPCs without updating the resolver value. The only requirement
+    # is to have DNS support enabled for the VPC.
+    resolver 169.254.169.253 ipv6=off;
 
     # Log accesses to stdout: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
     access_log /dev/stdout;

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -20,14 +20,8 @@ events {
 }
 
 http {
-    # Configure the DNS that nginx uses to connect to the servers it's proxying.
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
-    # Here we are setting the value of the resolver to the AWS VPC DNS server.
-    # Each AWS VPC has a DNS server available at the CIDR base + 2 address.
-    # 169.254.169.253 is mapped to what ever that value is meaning we can deploy
-    # in other AWS VPCs without updating the resolver value. The only requirement
-    # is to have DNS support enabled for the VPC.
-    resolver 169.254.169.253 ipv6=off;
+    # Configure DNS resolution
+    include includes/resolver.conf;
 
     # Log accesses to stdout: http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
     access_log /dev/stdout;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro
       - ./conf/nginx/includes/secure_links.conf:/etc/nginx/includes/secure_links.conf:ro
       - ./conf/nginx/includes.dev/app_upstream.conf:/etc/nginx/includes/app_upstream.conf:ro
+      - ./conf/nginx/includes.dev/resolver.conf:/etc/nginx/includes/resolver.conf:ro
       - ./conf/nginx/dev_host_bridge.sh:/etc/nginx/dev_host_bridge.sh:ro
       - ./conf/nginx/envsubst.conf.template:/var/lib/hypothesis/nginx_envsubst.conf.template:ro
     command: /bin/sh -c "/etc/nginx/dev_host_bridge.sh && envsubst '$${GOOGLE_API_KEY}:$${NGINX_SECURE_LINK_SECRET}' < /var/lib/hypothesis/nginx_envsubst.conf.template > /var/lib/hypothesis/nginx_envsubst.conf && exec nginx"


### PR DESCRIPTION
This commit updates the value of the resolver parameter used in `nginx.conf`. The value provided is the hard coded to `169.254.169.253` which is the AWS VPC DNS. This will break functionality if running outside of AWS.