### PR TITLE
Use built-in `tojson` to escape JSON strings

### DIFF
--- a/via/templates/pdf_viewer.html.jinja2
+++ b/via/templates/pdf_viewer.html.jinja2
@@ -18,9 +18,8 @@
 
 {% block footer %}
     <script>
-        {# These values come pre-escaped by the backend #}
-        window.PDF_URL = {{ pdf_url }};
-        window.CLIENT_EMBED_URL = {{ client_embed_url }};
+        window.PDF_URL = {{ pdf_url | tojson }};
+        window.CLIENT_EMBED_URL = {{ client_embed_url | tojson }};
     </script>
 
     <script src="{{ static_url("via:static/js/pdfjs-init.min.js") }}"></script>

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -1,12 +1,10 @@
 """View presenting the PDF viewer."""
 import hashlib
-import json
 from base64 import b64encode
 from datetime import timedelta
 
 from h_vialib import Configuration
 from h_vialib.secure import quantized_expiry
-from markupsafe import Markup
 from pyramid import view
 
 from via.views.decorators import checkmate_block, has_secure_url_token
@@ -34,9 +32,7 @@ def view_pdf(context, request):
 
     return {
         "pdf_url": pdf_url,
-        "client_embed_url": _string_literal(
-            request.registry.settings["client_embed_url"]
-        ),
+        "client_embed_url": request.registry.settings["client_embed_url"],
         "static_url": request.static_url,
         "hypothesis_config": h_config,
     }
@@ -70,10 +66,4 @@ def _pdf_url(url, nginx_server, secret):
 
     # Construct the URL, inserting sec and exp where our NGINX config file
     # expects to find them.
-    return _string_literal(f"{nginx_server}/proxy/static/{sec}/{exp}/{url}")
-
-
-def _string_literal(string):
-    """Return a JSON escaped, but otherwise un-modified string."""
-
-    return Markup(json.dumps(str(string)))
+    return f"{nginx_server}/proxy/static/{sec}/{exp}/{url}"


### PR DESCRIPTION
_This is preparation for fixing https://github.com/hypothesis/via3/issues/372_.

Use Jinja2's built in `tojson` filter to escape JSON data rather than
doing it ourselves in the view function:

 - It avoids the view functions needing to deal with escaping issues and
   moves the escaping closer to the sink, reducing the risk of
   context-inappropriate escaping.

 - This avoids a potential hazard specific to escaping JSON
   data in `<script>` contexts [1], where additional escaping is required (see
   the `htmlsafe_json_dumps` function in Jinja2 [2])

[1] https://sophiebits.com/2012/08/03/preventing-xss-json.html
[2] https://github.com/pallets/jinja/blob/8ab9db26f36a976212debd02a7a46265fa6dd1c1/src/jinja2/utils.py#L613