### PR TITLE
Jenkinsfile - Updated to support parallel builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,15 +41,38 @@ node {
 
 onlyOnMaster {
     milestone()
-    stage("qa deploy") {
-        deployApp(image: img, app: "via3", env: "qa")
+    stage("Deploy (qa)") {
+	lock("qa deploy") {
+	    parallel(
+	        lms: {
+		    sleep 2
+		    deployApp(image: img, app: "via3", env: "qa")
+		},
+		public: {
+		    deployApp(image: img, app: "via", env: "qa")
+		}
+	    )
+	}
     }
 
     milestone()
-    stage("prod deploy") {
-        input(message: "Deploy to prod?")
-        milestone()
-        deployApp(image: img, app: "via3", env: "prod")
+    stage("Approval") {
+        input(message: "Proceed to production deploy?")
+    }
+
+    milestone()
+    stage("Deploy (prod)") {
+	lock("prod deploy") {
+	    parallel(
+	        lms: {
+		    sleep 2
+		    deployApp(image: img, app: "via3", env: "prod")
+		},
+		public: {
+		    deployApp(image: img, app: "via", env: "prod")
+		}
+	    )
+	}
     }
 }
 


### PR DESCRIPTION
This commit updates the Via3 Jenkinsfile to enable parallel builds of both via3(lms), and via(public) environments.

In addition, the approval has been broken out into its own stage to make it easier to see what is going on.