### PR TITLE
Optionally use allow list

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ def pyramid_settings():
         "signed_urls_required": False,
         "checkmate_api_key": "dev_api_key",
         "checkmate_ignore_reasons": None,
+        "checkmate_allow_all": False,
     }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: CHECKMATE_URL = http://localhost:9099
     dev: CHECKMATE_IGNORE_REASONS = {env:CHECKMATE_IGNORE_REASONS:publisher-blocked}
+    dev: CHECKMATE_ALLOW_ALL = {env:CHECKMATE_ALLOW_ALL:true}
     dev: NGINX_SECURE_LINK_SECRET = not_a_secret
     dev: VIA_SECRET = not_a_secret
     dev: CHECKMATE_API_KEY = dev_api_key

--- a/via/app.py
+++ b/via/app.py
@@ -20,6 +20,7 @@ PARAMETERS = {
     "nginx_secure_link_secret": {"required": True},
     # Optional
     "checkmate_ignore_reasons": {},
+    "checkmate_allow_all": {"formatter": asbool},
     "signed_urls_required": {"formatter": asbool},
 }
 

--- a/via/views/decorators.py
+++ b/via/views/decorators.py
@@ -23,7 +23,7 @@ def checkmate_block(view):
         try:
             blocked = checkmate.check_url(
                 url,
-                allow_all=True,
+                allow_all=request.registry.settings["checkmate_allow_all"],
                 blocked_for=blocked_for,
                 ignore_reasons=request.registry.settings["checkmate_ignore_reasons"],
             )

--- a/via/views/decorators.py
+++ b/via/views/decorators.py
@@ -5,13 +5,10 @@ from h_vialib.secure.url import ViaSecureURL
 from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPUnauthorized
 
 
-def checkmate_block(view, url_param="url", allow_all=True):
+def checkmate_block(view):
     """Intended to be used as a decorator for pyramid views.
 
     The view must accept a url a query param.
-
-    :param url_param name of the query param that contains the URL to check
-    :allow_all Check against checkmate's allow list (True) or not.
     """
 
     def view_wrapper(context, request):
@@ -20,13 +17,13 @@ def checkmate_block(view, url_param="url", allow_all=True):
             request.registry.settings["checkmate_api_key"],
         )
 
-        url = request.params[url_param]
+        url = request.params["url"]
         blocked_for = request.params.get("via.blocked_for")
 
         try:
             blocked = checkmate.check_url(
                 url,
-                allow_all=allow_all,
+                allow_all=True,
                 blocked_for=blocked_for,
                 ignore_reasons=request.registry.settings["checkmate_ignore_reasons"],
             )

--- a/via/views/decorators.py
+++ b/via/views/decorators.py
@@ -17,14 +17,11 @@ def checkmate_block(view):
             request.registry.settings["checkmate_api_key"],
         )
 
-        url = request.params["url"]
-        blocked_for = request.params.get("via.blocked_for")
-
         try:
             blocked = checkmate.check_url(
-                url,
+                request.params["url"],
                 allow_all=request.registry.settings["checkmate_allow_all"],
-                blocked_for=blocked_for,
+                blocked_for=request.params.get("via.blocked_for"),
                 ignore_reasons=request.registry.settings["checkmate_ignore_reasons"],
             )
         except CheckmateException:


### PR DESCRIPTION
Instead of just the blocklist.

Adds a `CHECKMATE_ALLOW_ALL` boolean envvar. This will be set to `True` for LMS's Via HTML and `False` for the public Via HTML.