### PR TITLE
Upgrade h-vialib to 1.0.14

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,11 @@
 #
 #    pip-compile requirements/build.in
 #
-htmlmin==0.1.12           # via -r requirements/build.in
-rcssmin==1.0.6            # via -r requirements/build.in
-rjsmin==1.1.0             # via -r requirements/build.in
-whitenoise==5.2.0         # via -r requirements/build.in
+htmlmin==0.1.12
+    # via -r requirements/build.in
+rcssmin==1.0.6
+    # via -r requirements/build.in
+rjsmin==1.1.0
+    # via -r requirements/build.in
+whitenoise==5.2.0
+    # via -r requirements/build.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ h-checkmatelib==1.0.7
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.13
+h-vialib==1.0.14
     # via -r requirements/requirements.txt
 hupper==1.10.2
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -32,7 +32,7 @@ h-matchers==1.2.10
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.13
+h-vialib==1.0.14
     # via -r requirements/requirements.txt
 httpretty==1.0.5
     # via -r requirements/functests.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -54,7 +54,7 @@ h-pyramid-sentry==1.2.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-h-vialib==1.0.13
+h-vialib==1.0.14
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,7 @@ h-checkmatelib==1.0.7
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.in
-h-vialib==1.0.13
+h-vialib==1.0.14
     # via -r requirements/requirements.in
 hupper==1.10.2
     # via pyramid

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -38,7 +38,7 @@ h-matchers==1.2.10
     # via -r requirements/tests.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
-h-vialib==1.0.13
+h-vialib==1.0.14
     # via -r requirements/requirements.txt
 httpretty==1.0.5
     # via -r requirements/tests.in

--- a/tests/functional/api/views/route_by_content_test.py
+++ b/tests/functional/api/views/route_by_content_test.py
@@ -10,8 +10,6 @@ from tests.conftest import assert_cache_control
 class TestRouteByContent:
     DEFAULT_OPTIONS = {
         "via.client.openSidebar": "1",
-        "via.client.requestConfigFromFrame.origin": "http://localhost",
-        "via.client.requestConfigFromFrame.ancestorLevel": "2",
         "via.external_link_mode": "new-tab",
     }
 

--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -16,7 +16,6 @@ class TestFactory:
 
         assert service == ViaClientService.return_value
         ViaClientService.assert_called_once_with(
-            host_url=pyramid_request.host_url,
             service_url=pyramid_request.host_url,
             html_service_url=sentinel.via_html_url,
             secret=sentinel.via_secret,

--- a/via/services/via_client.py
+++ b/via/services/via_client.py
@@ -12,8 +12,6 @@ def factory(_context, request):
     settings = request.registry.settings
 
     return ViaClientService(
-        # Where we are coming from
-        host_url=request.host_url,
         # Where we are going for general / HTML specifically
         service_url=request.host_url,
         html_service_url=settings["via_html_url"],


### PR DESCRIPTION
In 1.0.14 h-vialib no longer adds the `via.client.requestConfigFromFrame.*` options to Via URLs by default, see: https://github.com/hypothesis/h-vialib/pull/23

As a result Via 3 will no longer add the `via.client.requestConfigFromFrame.*` when it generates Via HTML URLs to redirect the browser to.

This is correct:

1. For LMS's Via 3 the LMS app will already have generated the `via.client.requestConfigFromFrame.*` when it generates the Via 3 URL and Via 3 will blindly pass these on to Via HTML.

2. In the future when Via 3 is used directly (as public Via) (so when Via 3 is *not* being redirected to by the LMS app) we actually don't want the `via.client.requestConfigFromFrame.*` options. Those options are only supposed to be used in LMS