### PR TITLE
Use DummyRequest

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,10 +1,9 @@
 # pylint: disable=no-self-use
 """A place to put fixture functions that are useful application-wide."""
 import functools
-from urllib.parse import urlencode
 
 from pyramid import testing
-from pyramid.request import Request, apply_request_extensions
+from pyramid.request import apply_request_extensions
 
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from via.views import add_routes
@@ -34,15 +33,9 @@ def pyramid_config(pyramid_settings):
 
 
 @pytest.fixture
-def make_request(pyramid_config):
-    def make_request(path="/irrelevant", params=None):
-        if params:
-            path += "?" + urlencode(params)
-
-        pyramid_request = Request.blank(path)
-        pyramid_request.registry = pyramid_config.registry
-        apply_request_extensions(pyramid_request)
-
-        return pyramid_request
-
-    return make_request
+def pyramid_request(
+    pyramid_config,  # pylint:disable=unused-argument
+):
+    pyramid_request = testing.DummyRequest()
+    apply_request_extensions(pyramid_request)
+    return pyramid_request

--- a/tests/unit/via/resources_test.py
+++ b/tests/unit/via/resources_test.py
@@ -5,16 +5,16 @@ from via.resources import URLResource
 
 
 class TestURLResource:
-    def test_it_returns_url(self, make_request):
-        url = "http://example.com"
-        context = URLResource(make_request(params={"url": url}))
+    def test_it_returns_url(self, pyramid_request):
+        url = pyramid_request.params["url"] = "http://example.com"
+        context = URLResource(pyramid_request)
 
         assert context.url() == url
 
     @pytest.mark.parametrize("params", ({}, {"urk": "foo"}, {"url": ""}))
-    def test_it_raises_HTTPBadRequest_for_bad_urls(self, params, make_request):
-        request = make_request(params=params)
-        context = URLResource(request)
+    def test_it_raises_HTTPBadRequest_for_bad_urls(self, params, pyramid_request):
+        pyramid_request.params = params
+        context = URLResource(pyramid_request)
 
         with pytest.raises(HTTPBadRequest):
             context.url()

--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -6,19 +6,18 @@ from via.services.via_client import factory
 
 
 class TestFactory:
-    def test_it(self, make_request, ViaClientService):
-        request = make_request()
-        request.registry.settings = {
+    def test_it(self, pyramid_request, ViaClientService):
+        pyramid_request.registry.settings = {
             "via_html_url": sentinel.via_html_url,
             "via_secret": sentinel.via_secret,
         }
 
-        service = factory(sentinel.context, request)
+        service = factory(sentinel.context, pyramid_request)
 
         assert service == ViaClientService.return_value
         ViaClientService.assert_called_once_with(
-            host_url=request.host_url,
-            service_url=request.host_url,
+            host_url=pyramid_request.host_url,
+            service_url=pyramid_request.host_url,
             html_service_url=sentinel.via_html_url,
             secret=sentinel.via_secret,
         )

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -2,7 +2,6 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
-from webob.headers import EnvironHeaders
 
 from tests.conftest import assert_cache_control
 from via.resources import URLResource
@@ -45,7 +44,7 @@ class TestRouteByContent:
         url = "http://example.com/path%2C?a=b"
         call_route_by_content(url, params={"other": "value"})
 
-        get_url_details.assert_called_once_with(url, Any.instance_of(EnvironHeaders))
+        get_url_details.assert_called_once_with(url, Any.instance_of(dict))
 
     @pytest.mark.parametrize(
         "content_type,max_age", [("application/pdf", 300), ("text/html", 60)]
@@ -82,14 +81,14 @@ class TestRouteByContent:
         assert result.headers == Any.iterable.containing({"Cache-Control": cache})
 
     @pytest.fixture
-    def call_route_by_content(self, make_request):
+    def call_route_by_content(self, pyramid_request):
         def call_route_by_content(
             target_url="http://example.com", params=None, settings=None
         ):
-            request = make_request(params=dict(params or {}, url=target_url))
-            context = URLResource(request)
+            pyramid_request.params = dict(params or {}, url=target_url)
+            context = URLResource(pyramid_request)
 
-            return route_by_content(context, request)
+            return route_by_content(context, pyramid_request)
 
         return call_route_by_content
 

--- a/tests/unit/via/views/status_test.py
+++ b/tests/unit/via/views/status_test.py
@@ -2,9 +2,7 @@ from via.views.status import get_status
 
 
 class TestStatusRoute:
-    def test_status_returns_200_response(self, make_request):
-        request = make_request("/_status")
-
-        result = get_status(request)
+    def test_status_returns_200_response(self, pyramid_request):
+        result = get_status(pyramid_request)
 
         assert result == {"status": "okay"}

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -63,11 +63,11 @@ class TestViewPDF:
         return Configuration
 
     @pytest.fixture
-    def call_view_pdf(self, make_request):
+    def call_view_pdf(self, pyramid_request):
         def call_view_pdf(url="http://example.com/name.pdf", params=None):
-            request = make_request(params=dict(params or {}, url=url))
-            context = URLResource(request)
-            return view_pdf(context, request)
+            pyramid_request.params = dict(params or {}, url=url)
+            context = URLResource(pyramid_request)
+            return view_pdf(context, pyramid_request)
 
         return call_view_pdf
 


### PR DESCRIPTION
Same as recently done for Checkmate:

https://github.com/hypothesis/checkmate/pull/280

Replace the `make_request` fixture that returns a function for creating real `Request` objects with a `pyramid_request` fixture that returns a `DummyRequest`.

The `make_request` fixture was making it difficult for me to add tests that I need to add on another branch both because it doesn't integrate with pytest fixtures (fixture overriding etc) in quite the same way (since the fixture returns a function that returns a request, rather than the fixture returning a request directly) and because it's not using `DummyRequest` (so e.g. you can't easily change the request params, and lots of other things).

The `pyramid_request` fixture is also in the style familiar from the rest of our apps.