### PR TITLE
Reflect the document title of proxied HTML content

### DIFF
--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -24,8 +24,45 @@
       padding: 0;
     }
   </style>
+
+  <script>
+  /**
+   * Perform basic validation of the structure of a notification from the content
+   * frame.
+   *
+   * Returns the input if valid or `null` otherwise.
+   */
+  function validateContentFrameMessage(data) {
+    if (!data || typeof data.type !== 'string') {
+      return null;
+    }
+    if (data.type === 'metadatachange' && data.metadata) {
+      return data;
+    } else {
+      return null;
+    }
+  }
+
+  // Listen for events from the proxied content in order to reflect document
+  // metadata etc. in the current frame.
+  window.addEventListener('message', event => {
+    const contentFrame = document.querySelector('.js-content-frame');
+    if (event.source !== contentFrame.contentWindow) {
+      return;
+    }
+
+    const message = validateContentFrameMessage(event.data);
+    if (!message) {
+      return;
+    }
+
+    if (message.type === 'metadatachange') {
+      document.title = `Via: ${message.metadata.title}`;
+    }
+  });
+  </script>
 </head>
   <body>
-    <iframe class="proxied-content-iframe" src={{ src }}></iframe>
+    <iframe class="js-content-frame proxied-content-iframe" src={{ src }}></iframe>
   </body>
 </html>


### PR DESCRIPTION
Listen for `metadatachange` messages sent via `window.postMessage` from
the viahtml iframe and update the document title of top frame to reflect
the current document in the proxied frame.

Currently the title is the only proxied metadata but the mechanism could
in future be extended to update the document URL, favicon etc.

Counterpart PR in Via 3: https://github.com/hypothesis/viahtml/pull/160

A note on JavaScript language compatibility: I am assuming a modern browser which is capable of running the Hypothesis client. See `browserslist` in the client repository's `package.json` file for a list of minimum supported browser versions.

Part of https://github.com/hypothesis/viahtml/issues/154