### PR TITLE
Allow Google to index the front page

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -159,12 +159,6 @@ http {
         }
 
         location / {
-            # At least for now we don't want Via 3's non-proxy pages (including
-            # the front page) to show in Google. Later (when Via 3 replaces the
-            # public Via service) we'll probably want at least the front page
-            # to be indexable.
-            include includes/robots.conf;
-
             # Proxy to the Gunicorn/Pyramid app.
             # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
             proxy_pass http://web;

--- a/tests/unit/via/tweens_test.py
+++ b/tests/unit/via/tweens_test.py
@@ -1,0 +1,39 @@
+from unittest.mock import create_autospec
+
+import pytest
+
+from via.tweens import robots_tween_factory
+
+
+class TestRobotsTween:
+    @pytest.mark.parametrize(
+        "existing_header,expected_header",
+        [
+            (None, "noindex, nofollow"),
+            ("all", "all"),
+        ],
+    )
+    def test_it(
+        self, existing_header, expected_header, handler, pyramid_request, tween
+    ):
+        if existing_header:
+            handler.return_value.headers = {"X-Robots-Tag": existing_header}
+        else:
+            handler.return_value.headers = {}
+
+        response = tween(pyramid_request)
+
+        handler.assert_called_once_with(pyramid_request)
+        assert response == handler.return_value
+        assert response.headers["X-Robots-Tag"] == expected_header
+
+    @pytest.fixture
+    def handler(self):
+        def handler_spec(request):
+            """Spec for mock handler function."""
+
+        return create_autospec(handler_spec)
+
+    @pytest.fixture
+    def tween(self, handler, pyramid_request):
+        return robots_tween_factory(handler, pyramid_request.registry)

--- a/via/app.py
+++ b/via/app.py
@@ -75,6 +75,8 @@ def create_app(_=None, **settings):
     # Make the CheckmateClient object available as request.checkmate.
     config.add_request_method(checkmate, reify=True)
 
+    config.add_tween("via.tweens.robots_tween_factory")
+
     app = WhiteNoise(
         config.make_wsgi_app(),
         index_file=True,

--- a/via/tweens.py
+++ b/via/tweens.py
@@ -1,0 +1,15 @@
+def robots_tween_factory(handler, _registry):
+    def robots_tween(request):
+        response = handler(request)
+
+        # If the view hasn't set its own X-Robots-Tag header then set one that
+        # tells Google (and most other crawlers) not to index the page and not
+        # to follow links on the page.
+        #
+        # https://developers.google.com/search/reference/robots_meta_tag
+        if "X-Robots-Tag" not in response.headers:
+            response.headers["X-Robots-Tag"] = "noindex, nofollow"
+
+        return response
+
+    return robots_tween

--- a/via/views/index.py
+++ b/via/views/index.py
@@ -13,6 +13,8 @@ class IndexViews:
         if not self.enabled:
             return HTTPNotFound()
 
+        self.request.response.headers["X-Robots-Tag"] = "all"
+
         return {}
 
     @view_config(request_method="POST")


### PR DESCRIPTION
Fixes https://github.com/hypothesis/checkmate/issues/168

With this PR we're still using NGINX to add the `X-Robots-Tag: noindex, nofollow` header to the proxied responses when NGINX proxies the actual PDF files. This has to be done in NGINX as those responses are handled directly by NGINX, no Python:

https://github.com/hypothesis/via3/blob/de537006593acbf3d5a6160e2822d3e5173d2d0f/conf/nginx/nginx.conf#L67

But we no longer use NGINX to add the header to the responses from Python. Instead we're using a Pyramid tween to add the header to every response from the Pyramid app. This makes sure that all of the Pyramid app's pages, including error pages, have the `X-Robots-Tag: noindex, nofollow` header.

The tween allows individual responses to opt-out of the `X-Robots-Tag: noindex, nofollow` by setting their own `X-Robots-Tag` header, and the view for the front page does this.

There is one unintended consequence of this: the tween doesn't add the header to static file responses served by [WhiteNoise](http://whitenoise.evans.io/en/stable/) whereas the previous NGINX-based approach to adding the header to every Python response did. I don't think this is important.