### PR TITLE
Add X-Robots-Tag header to error pages

### DIFF
--- a/conf/nginx/includes/robots.conf
+++ b/conf/nginx/includes/robots.conf
@@ -2,4 +2,4 @@
 #
 # https://developers.google.com/search/reference/robots_meta_tag
 
-add_header "X-Robots-Tag" "noindex, nofollow";
+add_header "X-Robots-Tag" "noindex, nofollow" always;


### PR DESCRIPTION
Also add the X-Robots-Tag header to any error responses served by the `/proxy/static` endpoint. See http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header