### PR TITLE
Factor out an unnecessary network round trip

### DIFF
--- a/tests/unit/via/get_url/details_test.py
+++ b/tests/unit/via/get_url/details_test.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
@@ -42,7 +43,7 @@ class TestGetURLDetails:
 
         url = "http://example.com"
 
-        result = get_url_details(url, headers={})
+        result = get_url_details(url, headers=sentinel.headers)
 
         assert result == (mime_type, status_code)
         requests.get.assert_called_once_with(
@@ -51,7 +52,7 @@ class TestGetURLDetails:
 
     @pytest.mark.usefixtures("response")
     def test_it_cleans_and_passes_on_the_users_headers(self, requests, clean_headers):
-        get_url_details(url="http://example.com", headers={})
+        get_url_details(url="http://example.com")
 
         _args, kwargs = requests.get.call_args
 
@@ -59,7 +60,7 @@ class TestGetURLDetails:
 
     def test_it_assumes_pdf_with_a_google_drive_url(self, requests):
         result = get_url_details(
-            "https://drive.google.com/uc?id=--FILEID--&export=download", {}
+            "https://drive.google.com/uc?id=--FILEID--&export=download"
         )
 
         assert result == ("application/pdf", 200)
@@ -69,7 +70,7 @@ class TestGetURLDetails:
     @pytest.mark.parametrize("bad_url", ("no-schema", "glub://example.com", "http://"))
     def test_it_raises_BadURL_for_invalid_urls(self, bad_url):
         with pytest.raises(BadURL):
-            get_url_details(bad_url, {})
+            get_url_details(bad_url)
 
     @pytest.mark.parametrize(
         "request_exception,expected_exception",
@@ -86,7 +87,7 @@ class TestGetURLDetails:
         requests.get.side_effect = request_exception("Oh noe")
 
         with pytest.raises(expected_exception):
-            get_url_details("http://example.com", {})
+            get_url_details("http://example.com")
 
     @pytest.fixture
     def response(self, requests):

--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -2,11 +2,53 @@ from unittest.mock import sentinel
 
 import pytest
 
-from via.services.via_client import factory
+from via.services.via_client import ViaClientService, factory
+
+
+class TestViaClientService:
+    @pytest.mark.parametrize(
+        "mime_type,is_pdf",
+        [
+            ("application/x-pdf", True),
+            ("application/pdf", True),
+            ("text/html", False),
+        ],
+    )
+    def test_is_pdf(self, mime_type, is_pdf, svc):
+        assert svc.is_pdf(mime_type) == is_pdf
+
+    @pytest.mark.parametrize(
+        "mime_type,expected_content_type",
+        [
+            ("application/pdf", "pdf"),
+            ("text/html", "html"),
+            (None, "html"),
+        ],
+    )
+    def test_url_for(self, mime_type, expected_content_type, svc, via_client):
+        params = {"foo": "bar"}
+
+        url = svc.url_for(sentinel.url, mime_type, params)
+
+        via_client.url_for.assert_called_once_with(
+            sentinel.url, expected_content_type, params
+        )
+        assert url == via_client.url_for.return_value
+
+    def test_url_for_pops_blocked_for_from_params(self, svc, via_client):
+        params = {"foo": "bar", "via.blocked_for": sentinel.blocked_for}
+
+        svc.url_for(sentinel.url, sentinel.mime_type, params)
+
+        assert via_client.url_for.call_args[1]["options"] == {"foo": "bar"}
+
+    @pytest.fixture
+    def svc(self, via_client):
+        return ViaClientService(via_client)
 
 
 class TestFactory:
-    def test_it(self, pyramid_request, ViaClientService):
+    def test_it(self, pyramid_request, ViaClient, ViaClientService):
         pyramid_request.registry.settings = {
             "via_html_url": sentinel.via_html_url,
             "via_secret": sentinel.via_secret,
@@ -14,13 +56,24 @@ class TestFactory:
 
         service = factory(sentinel.context, pyramid_request)
 
-        assert service == ViaClientService.return_value
-        ViaClientService.assert_called_once_with(
+        ViaClient.assert_called_once_with(
             service_url=pyramid_request.host_url,
             html_service_url=sentinel.via_html_url,
             secret=sentinel.via_secret,
         )
+        ViaClientService.assert_called_once_with(ViaClient.return_value)
+        assert service == ViaClientService.return_value
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def ViaClientService(self, patch):
         return patch("via.services.via_client.ViaClientService")
+
+
+@pytest.fixture(autouse=True)
+def ViaClient(patch):
+    return patch("via.services.via_client.ViaClient")
+
+
+@pytest.fixture
+def via_client(ViaClient):
+    return ViaClient.return_value

--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -35,13 +35,6 @@ class TestViaClientService:
         )
         assert url == via_client.url_for.return_value
 
-    def test_url_for_pops_blocked_for_from_params(self, svc, via_client):
-        params = {"foo": "bar", "via.blocked_for": sentinel.blocked_for}
-
-        svc.url_for(sentinel.url, sentinel.mime_type, params)
-
-        assert via_client.url_for.call_args[1]["options"] == {"foo": "bar"}
-
     @pytest.fixture
     def svc(self, via_client):
         return ViaClientService(via_client)

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import sentinel
+
 import pytest
 
 from via.views.proxy import proxy
@@ -10,15 +12,27 @@ class TestProxy:
             ("/https://example.com/foo", "https://example.com/foo"),
             ("/http://example.com/foo", "http://example.com/foo"),
             ("/example.com/foo", "https://example.com/foo"),
+            (
+                "/https://example.com/foo?bar=gar&har=jar#car",
+                "https://example.com/foo?bar=gar&har=jar#car",
+            ),
         ],
     )
-    def test_it(self, pyramid_request, path, url_to_proxy):
+    def test_it(
+        self, pyramid_request, path, url_to_proxy, get_url_details, via_client_service
+    ):
         pyramid_request.path = path
 
         result = proxy(pyramid_request)
 
-        assert result == {
-            "src": pyramid_request.route_url(
-                "route_by_content", _query={"url": url_to_proxy}
-            )
-        }
+        get_url_details.assert_called_once_with(url_to_proxy)
+        via_client_service.url_for.assert_called_once_with(
+            url_to_proxy, sentinel.mime_type, pyramid_request.params
+        )
+        assert result == {"src": via_client_service.url_for.return_value}
+
+    @pytest.fixture(autouse=True)
+    def get_url_details(self, patch):
+        get_url_details = patch("via.views.proxy.get_url_details")
+        get_url_details.return_value = (sentinel.mime_type, sentinel.status_code)
+        return get_url_details

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import sentinel
+from unittest.mock import create_autospec, sentinel
 
 import pytest
-from h_matchers import Any
 
 from tests.conftest import assert_cache_control
+from tests.unit.matchers import temporary_redirect_to
 from via.resources import URLResource
 from via.views.route_by_content import route_by_content
 
@@ -11,90 +11,50 @@ from via.views.route_by_content import route_by_content
 @pytest.mark.usefixtures("via_client_service")
 class TestRouteByContent:
     @pytest.mark.parametrize(
-        "content_type,passed_type",
-        (
-            ("application/x-pdf", "pdf"),
-            ("application/pdf", "pdf"),
-            ("text/html", "html"),
-            ("other", "html"),
-        ),
+        "content_type,status_code,expected_cache_control_header",
+        [
+            ("PDF", 200, "public, max-age=300, stale-while-revalidate=86400"),
+            ("HTML", 200, "public, max-age=60, stale-while-revalidate=86400"),
+            ("HTML", 401, "public, max-age=60, stale-while-revalidate=86400"),
+            ("HTML", 404, "public, max-age=60, stale-while-revalidate=86400"),
+            ("HTML", 500, "no-cache"),
+            ("HTML", 501, "no-cache"),
+        ],
     )
-    def test_it_routes_by_content_type(
+    def test_it(
         self,
         content_type,
-        passed_type,
-        call_route_by_content,
+        context,
+        expected_cache_control_header,
         get_url_details,
+        pyramid_request,
+        status_code,
         via_client_service,
     ):
-        url = "http://example.com/path%2C?a=b"
-        get_url_details.return_value = (content_type, 200)
+        pyramid_request.params = {"url": sentinel.url, "foo": "bar"}
+        get_url_details.return_value = (sentinel.mime_type, status_code)
+        via_client_service.is_pdf.return_value = content_type == "PDF"
 
-        results = call_route_by_content(url, params={"other": "value"})
+        response = route_by_content(context, pyramid_request)
 
+        get_url_details.assert_called_once_with(
+            context.url.return_value, pyramid_request.headers
+        )
+        via_client_service.is_pdf.assert_called_once_with(sentinel.mime_type)
         via_client_service.url_for.assert_called_once_with(
-            url, content_type=passed_type, options={"other": "value"}
+            context.url.return_value, sentinel.mime_type, {"foo": "bar"}
         )
-
-        assert results.location == via_client_service.url_for.return_value
-
-    def test_we_call_third_parties_correctly(
-        self, call_route_by_content, get_url_details
-    ):
-        url = "http://example.com/path%2C?a=b"
-        call_route_by_content(url, params={"other": "value"})
-
-        get_url_details.assert_called_once_with(url, Any.instance_of(dict))
-
-    @pytest.mark.parametrize(
-        "content_type,max_age", [("application/pdf", 300), ("text/html", 60)]
-    )
-    def test_sets_correct_cache_control(
-        self, content_type, max_age, call_route_by_content, get_url_details
-    ):
-        get_url_details.return_value = (content_type, 200)
-
-        result = call_route_by_content()
-
+        assert response == temporary_redirect_to(
+            via_client_service.url_for.return_value
+        )
         assert_cache_control(
-            result.headers,
-            ["public", f"max-age={max_age}", "stale-while-revalidate=86400"],
+            response.headers, expected_cache_control_header.split(", ")
         )
-
-    @pytest.mark.parametrize(
-        "status_code,cache",
-        (
-            (200, Any.string.containing("max-age=60")),
-            (401, Any.string.containing("max-age=60")),
-            (404, Any.string.containing("max-age=60")),
-            (500, "no-cache"),
-            (501, "no-cache"),
-        ),
-    )
-    def test_cache_http_response_codes_appropriately(
-        self, status_code, cache, call_route_by_content, get_url_details
-    ):
-        get_url_details.return_value = (sentinel.content_type, status_code)
-
-        result = call_route_by_content()
-
-        assert result.headers == Any.iterable.containing({"Cache-Control": cache})
 
     @pytest.fixture
-    def call_route_by_content(self, pyramid_request):
-        def call_route_by_content(
-            target_url="http://example.com", params=None, settings=None
-        ):
-            pyramid_request.params = dict(params or {}, url=target_url)
-            context = URLResource(pyramid_request)
-
-            return route_by_content(context, pyramid_request)
-
-        return call_route_by_content
+    def context(self):
+        return create_autospec(URLResource, spec_set=True, instance=True)
 
     @pytest.fixture(autouse=True)
     def get_url_details(self, patch):
-        get_url_details = patch("via.views.route_by_content.get_url_details")
-        get_url_details.return_value = (sentinel.content_type, 200)
-
-        return get_url_details
+        return patch("via.views.route_by_content.get_url_details")

--- a/via/get_url/details.py
+++ b/via/get_url/details.py
@@ -41,7 +41,7 @@ def _handle_errors(inner):
 
 
 @_handle_errors
-def get_url_details(url, headers):
+def get_url_details(url, headers=None):
     """Get the content type and status code for a given URL.
 
     :param url: URL to retrieve
@@ -52,6 +52,8 @@ def get_url_details(url, headers):
     :raise UpstreamServiceError: If we server gives us errors
     :raise UnhandledException: For all other request based errors
     """
+    if headers is None:
+        headers = {}
 
     if GOOGLE_DRIVE_REGEX.match(url):
         return "application/pdf", 200

--- a/via/services/via_client.py
+++ b/via/services/via_client.py
@@ -15,13 +15,11 @@ class ViaClientService:
 
     def url_for(self, url, mime_type, params):
         """Return a Via URL for the given `url`."""
-        content_type = "pdf" if self.is_pdf(mime_type) else "html"
-
-        options = dict(params)
-
-        options.pop("via.blocked_for", None)
-
-        return self.via_client.url_for(url, content_type=content_type, options=options)
+        return self.via_client.url_for(
+            url,
+            content_type="pdf" if self.is_pdf(mime_type) else "html",
+            options=params,
+        )
 
 
 def factory(_context, request):

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,5 +1,8 @@
 from pyramid.view import view_config
 
+from via.get_url import get_url_details
+from via.services import ViaClientService
+
 
 @view_config(route_name="proxy", renderer="via:templates/proxy.html.jinja2")
 def proxy(request):
@@ -10,4 +13,10 @@ def proxy(request):
     if not (url.startswith("http://") or url.startswith("https://")):
         url = "https://" + url
 
-    return {"src": request.route_url("route_by_content", _query={"url": url})}
+    mime_type, _status_code = get_url_details(url)
+
+    return {
+        "src": request.find_service(ViaClientService).url_for(
+            url, mime_type, request.params
+        )
+    }


### PR DESCRIPTION
Fixes https://github.com/hypothesis/via3/issues/451

Problem
-------

URLs like `https://via.hypothes.is/https://example.com` are served by
the `proxy()` view which renders a page containing
`<iframe src="https://via.hypothes.is/route?url=https://example.com">`.
This iframe URL is served by Via's `route_by_content()` view which checks
whether `https://example.com` returns HTML or PDF and redirects the
iframe to either `https://via.hypothes.is/pdf?url=https://example.com`
or `https://viahtml.hypothes.is/proxy/https://example.com`.

This redirect of the iframe is an unnecessary network round trip.

Solution
--------

Change the `proxy()` view to do the check of whether `https://example.com` is
HTML or PDF itself, exactly as the `route_by_content()` view does, and
inject `https://via.hypothes.is/pdf?url=https://example.com` or
`https://viahtml.hypothes.is/proxy/https://example.com` as the iframe
URL directly instead of going through `route_by_content()`.

This requires some refactoring to move the HTML-or-PDF test out of the
`route_by_content()` view and into `ViaClientService` where it can be
called by both the `route_by_content()` and `proxy()` views.

`route_by_content()` is unchanged
---------------------------------

This PR doesn't change `route_by_content()`'s behavior, it still
redirects as before, it's just that the `proxy()` view no longer uses
it.

Arguably `route_by_content()` isn't needed anymore: the LMS app could
inject the `proxy()` route's
`https://via.hypothes.is/https://example.com` URL as the `src` of its
`iframe`. This would be less code and more consistency between Via in
the LMS and public contexts.

But it would mean an iframe-within-an-iframe in the LMS context and,
more importantly, it might create URL-encoding issues with things like
Canvas files with unusual characters in their filenames that're
important in the LMS context but not in the public context. There were
lots of tricky URL-encoding differences in LMS to do with encodings
being handled differently when the URL is in the path or in a query
string, and differences between Python and NGINX. After much difficulty
we got it all working, so now I don't want to change it.