### PR TITLE
Add abuse and complaints links to response headers

### DIFF
--- a/conf/nginx/includes/abuse_response_headers.conf
+++ b/conf/nginx/includes/abuse_response_headers.conf
@@ -1,0 +1,4 @@
+# Add links to our abuse policy in response headers.
+
+add_header "X-Abuse-Policy" "https://web.hypothes.is/abuse-policy/" always;
+add_header "X-Complaints-To" "https://web.hypothes.is/report-abuse/" always;

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -90,6 +90,8 @@ http {
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "static-proxy, direct";
+
+            include includes/abuse_response_headers.conf;
         }
 
         location @handle_redirect {
@@ -176,6 +178,8 @@ http {
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "compute";
+
+            include includes/abuse_response_headers.conf;
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./conf/nginx/includes/proxy.conf:/etc/nginx/includes/proxy.conf:ro
       - ./conf/nginx/includes/errors.conf:/etc/nginx/includes/errors.conf:ro
       - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro
+      - ./conf/nginx/includes/abuse_response_headers.conf:/etc/nginx/includes/abuse_response_headers.conf:ro
       - ./conf/nginx/includes/secure_links.conf:/etc/nginx/includes/secure_links.conf:ro
       - ./conf/nginx/includes.dev/app_upstream.conf:/etc/nginx/includes/app_upstream.conf:ro
       - ./conf/nginx/includes.dev/resolver.conf:/etc/nginx/includes/resolver.conf:ro


### PR DESCRIPTION
This adds X-Abuse-Policy and X-Complaints-To headers to all Via 3 responses, including the /proxy/static/ responses that're proxying third-party PDFs and all other non-proxy responses.

See this Slack thread for the choice of headers:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1619616535474700?thread_ts=1619615485.468500&cid=C4K6M7P5E

Part of https://github.com/hypothesis/checkmate/issues/70