### PR TITLE
Add abuse policy NGINX request headers

### DIFF
--- a/conf/nginx/includes/proxy.conf
+++ b/conf/nginx/includes/proxy.conf
@@ -11,6 +11,12 @@
 # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
 proxy_ssl_server_name on;
 
+# Pass our abuse policy in request headers for third-party site admins.
+#
+# https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
+proxy_set_header "X-Abuse-Policy" "https://web.hypothes.is/abuse-policy/";
+proxy_set_header "X-Complaints-To" "https://web.hypothes.is/report-abuse/";
+
 # Rewrite drive.google.com URLs to googleapis.com ones that use our API key.
 #
 # This is because Google gives us a much higher rate limit / quota when we use


### PR DESCRIPTION
This adds X-Abuse-Policy and X-Complaints-To headers to the requests
that Via 3's NGINX sends to third-party servers when proxying their PDF
files.

This does not add the headers to the requests that the Python app sends
to determine with a URL is PDF or HTML, separate PR for that.

via_test_app contains a Python view that returns a PDF file and I was
able to use the view to verify that the request headers are received.

See this Slack thread for the choice of headers:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1619616535474700?thread_ts=1619615485.468500&cid=C4K6M7P5E

Part of hypothesis/checkmate#70