### PR TITLE
Add abuse policy headers

### DIFF
--- a/conf/nginx/includes/abuse_response_headers.conf
+++ b/conf/nginx/includes/abuse_response_headers.conf
@@ -1,0 +1,4 @@
+# Add links to our abuse policy in response headers.
+
+add_header "X-Abuse-Policy" "https://web.hypothes.is/abuse-policy/" always;
+add_header "X-Complaints-To" "https://web.hypothes.is/report-abuse/" always;

--- a/conf/nginx/includes/proxy.conf
+++ b/conf/nginx/includes/proxy.conf
@@ -11,6 +11,12 @@
 # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
 proxy_ssl_server_name on;
 
+# Pass our abuse policy in request headers for third-party site admins.
+#
+# https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
+proxy_set_header "X-Abuse-Policy" "https://web.hypothes.is/abuse-policy/";
+proxy_set_header "X-Complaints-To" "https://web.hypothes.is/report-abuse/";
+
 # Rewrite drive.google.com URLs to googleapis.com ones that use our API key.
 #
 # This is because Google gives us a much higher rate limit / quota when we use

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -90,6 +90,8 @@ http {
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "static-proxy, direct";
+
+            include includes/abuse_response_headers.conf;
         }
 
         location @handle_redirect {
@@ -176,6 +178,8 @@ http {
 
             # Add an X-Via header for debugging.
             add_header "X-Via" "compute";
+
+            include includes/abuse_response_headers.conf;
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./conf/nginx/includes/proxy.conf:/etc/nginx/includes/proxy.conf:ro
       - ./conf/nginx/includes/errors.conf:/etc/nginx/includes/errors.conf:ro
       - ./conf/nginx/includes/robots.conf:/etc/nginx/includes/robots.conf:ro
+      - ./conf/nginx/includes/abuse_response_headers.conf:/etc/nginx/includes/abuse_response_headers.conf:ro
       - ./conf/nginx/includes/secure_links.conf:/etc/nginx/includes/secure_links.conf:ro
       - ./conf/nginx/includes.dev/app_upstream.conf:/etc/nginx/includes/app_upstream.conf:ro
       - ./conf/nginx/includes.dev/resolver.conf:/etc/nginx/includes/resolver.conf:ro

--- a/tests/unit/via/get_url/details_test.py
+++ b/tests/unit/via/get_url/details_test.py
@@ -58,6 +58,14 @@ class TestGetURLDetails:
 
         assert kwargs["headers"] == clean_headers.return_value
 
+    @pytest.mark.usefixtures("response")
+    def test_it_adds_abuse_policy_headers(self, requests):
+        get_url_details(url="http://example.com", headers={})
+
+        headers = requests.get.call_args[1]["headers"]
+        assert headers["X-Abuse-Policy"] == "https://web.hypothes.is/abuse-policy/"
+        assert headers["X-Complaints-To"] == "https://web.hypothes.is/report-abuse/"
+
     def test_it_assumes_pdf_with_a_google_drive_url(self, requests):
         result = get_url_details(
             "https://drive.google.com/uc?id=--FILEID--&export=download"
@@ -105,4 +113,4 @@ class TestGetURLDetails:
 
     @pytest.fixture(autouse=True)
     def clean_headers(self, patch):
-        return patch("via.get_url.details.clean_headers")
+        return patch("via.get_url.details.clean_headers", return_value={})

--- a/via/get_url/details.py
+++ b/via/get_url/details.py
@@ -1,6 +1,7 @@
 """Retrieve details about a resource at a URL."""
 import cgi
 import re
+from collections import OrderedDict
 from functools import wraps
 
 import requests
@@ -53,16 +54,21 @@ def get_url_details(url, headers=None):
     :raise UnhandledException: For all other request based errors
     """
     if headers is None:
-        headers = {}
+        headers = OrderedDict()
 
     if GOOGLE_DRIVE_REGEX.match(url):
         return "application/pdf", 200
+
+    headers = clean_headers(headers)
+    # Pass our abuse policy in request headers for third-party site admins.
+    headers["X-Abuse-Policy"] = "https://web.hypothes.is/abuse-policy/"
+    headers["X-Complaints-To"] = "https://web.hypothes.is/report-abuse/"
 
     with requests.get(
         url,
         stream=True,
         allow_redirects=True,
-        headers=clean_headers(headers),
+        headers=headers,
         timeout=10,
     ) as rsp:
         content_type = rsp.headers.get("Content-Type")


### PR DESCRIPTION
This adds `X-Abuse-Policy` and `X-Complaints-To` headers to:

* The requests that Via 3's Python app sends to third-party servers when testing whether a URL is HTML or PDF
* The requests that Via 3's NGINX sends to third-party servers when proxying PDF files
* All Via 3's responses (both the ones that're proxying third-party PDF files and all the non-proxy responses)

I was able to use via_test_app to verify that the request headers are received.

Part of https://github.com/hypothesis/checkmate/issues/70

See this Slack thread for the choice of headers: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1619616535474700?thread_ts=1619615485.468500&cid=C4K6M7P5E