### PR TITLE
Fix direct links in new Via implementation

### DIFF
--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -160,7 +160,23 @@
         const loadingIndicator = document.querySelector('.js-loading-indicator');
         setTimeout(() => loadingIndicator.classList.add('is-loading'), 500);
       }
+
+      /**
+       * Copy the fragment from the top frame's URL to the iframe's URL.
+       *
+       * This is needed so that direct links to annotations, which use a
+       * `#annotations:` fragment, are respected by the client in the iframe.
+       */
+      function copyFragmentToFrame() {
+        const fragment = location.hash;
+        if (fragment) {
+          const iframe = document.querySelector('.js-content-frame');
+          iframe.src += fragment;
+        }
+      }
+
       showLoadingIndicator();
+      copyFragmentToFrame();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Direct links were not working in Via 3 because the `#annotations:` URL
fragment added to the Via URL by the bouncer service is not propagated
to the iframe and hence were never seen by the client.

This commit fixes the issue by using JS to update the fragment of the
iframe URL. This change assumes that:

 - The script will always run before the client has been able to load. I
   believe this is a safe assumption.

 - It is OK to blindly copy all fragments to the child iframe without
   any filtering. This has a benefit that it enables regular anchors in
   the page to work.

Fixes https://github.com/hypothesis/via3/issues/472

----

**Testing:**

1. Navigate to http://localhost:9083/example.com and make an annotation
2. Click on the annotation's timestamp and copy the annotation ID from the URL
3. Navigate to http://localhost:9083/example.com#annotations:<annotation ID>

This should load example.com and select the specified annotation in the client. The same steps should also work with a PDF (eg. https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf)