### PR TITLE
Reflect proxied document URL in top frame URL

### DIFF
--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -150,7 +150,7 @@
       // URL shouldn't be retained in the tab's history. If we update the URL
       // in response to client-side URL changes in the iframe in future, we'll
       // probably want to change this.
-      const viaURL = `${location.origin}/${metadata.location}`;
+      const viaURL = `/${metadata.location}`;
       history.replaceState(null, document.title, viaURL);
     }
   });

--- a/via/templates/proxy.html.jinja2
+++ b/via/templates/proxy.html.jinja2
@@ -139,7 +139,19 @@
       // ViaHTML iframe, so sub-resources on the page may still be loading.
       loadingIndicator.classList.add('is-done');
 
-      document.title = `Via: ${message.metadata.title}`;
+      const metadata = message.metadata;
+      document.title = `Via: ${metadata.title}`;
+
+      // Sync top frame URL with the URL being proxied inside the iframe.
+      // This may be different than the originally requested URL if it redirected.
+      //
+      // We currently use `replaceState` rather than `pushState` on the assumption
+      // that if the URL changed it did so because of a redirect and so the previous
+      // URL shouldn't be retained in the tab's history. If we update the URL
+      // in response to client-side URL changes in the iframe in future, we'll
+      // probably want to change this.
+      const viaURL = `${location.origin}/${metadata.location}`;
+      history.replaceState(null, document.title, viaURL);
     }
   });
   </script>


### PR DESCRIPTION
Update the URL of the top frame to reflect the proxied URL currently displayed in the content frame. This may be different than the initially requested URL if it redirected.

For example https://stackoverflow.com/questions/{id}/ redirects to https://stackoverflow.com/questions/{id}/{slug}. When visiting https://via.hypothes.is/https://stackoverflow.com/{id} the URL should be updated to https://via.hypothes.is/https://stackoverflow.com/{id}/{slug} accordingly.

Depends on https://github.com/hypothesis/viahtml/pull/170 and fixes https://github.com/hypothesis/viahtml/issues/156.

**Testing:**

1. Check out https://github.com/hypothesis/viahtml/pull/170 in the viahtml repo
2. Check out this branch
3. Visit http://localhost:9083/https://stackoverflow.com/questions/12339806/

Once the document has loaded, the URL should be updated to http://localhost:9083/https://stackoverflow.com/questions/12339806/escape-strings-for-javascript-using-jinja2.

When annotating PDFs the code here runs, but you won't see the expected effect due to https://github.com/hypothesis/via3/issues/480.