### PR TITLE
Fix query string and leading/trailing whitespace handling on the index page

### DIFF
--- a/tests/functional/via/views/index_test.py
+++ b/tests/functional/via/views/index_test.py
@@ -13,12 +13,14 @@ from tests.functional.matchers import temporary_redirect_to
             "http://localhost/https://example.com/foo/",
         ),
         (
-            "example.com/foo/",
-            "http://localhost/example.com/foo/",
-        ),
-        (
             "http://example.com/foo/",
             "http://localhost/http://example.com/foo/",
+        ),
+        # The submitted URL is normalized to strip leading/trailing spaces and
+        # add a protocol.
+        (
+            "example.com/foo/",
+            "http://localhost/https://example.com/foo/",
         ),
         # If you submit an empty form it just reloads the front page again.
         ("", "http://localhost/"),

--- a/tests/unit/via/views/_helpers_test.py
+++ b/tests/unit/via/views/_helpers_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from via.views._helpers import url_from_user_input
+
+
+class TestURLFromUserInput:
+    @pytest.mark.parametrize(
+        "input_url, expected",
+        [
+            # URLs that should be returned unchanged
+            ("http://example.com", "http://example.com"),
+            ("https://example.com", "https://example.com"),
+            # URLs without a protocol that should have `https://` prefixed
+            ("example.com", "https://example.com"),
+            # Leading and trailing whitespace that should be stripped
+            (" http://example.com", "http://example.com"),
+            ("http://example.com ", "http://example.com"),
+            # Empty URLs that should return an empty string
+            ("", ""),
+            ("  ", ""),
+        ],
+    )
+    def test_it(self, input_url, expected):
+        assert url_from_user_input(input_url) == expected

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -11,7 +11,6 @@ class TestProxy:
         [
             ("/https://example.com/foo", "https://example.com/foo"),
             ("/http://example.com/foo", "http://example.com/foo"),
-            ("/example.com/foo", "https://example.com/foo"),
             (
                 "/https://example.com/foo?bar=gar&har=jar#car",
                 "https://example.com/foo?bar=gar&har=jar#car",
@@ -31,8 +30,28 @@ class TestProxy:
         )
         assert result == {"src": via_client_service.url_for.return_value}
 
+    def test_it_normalizes_url(
+        self, pyramid_request, get_url_details, via_client_service, url_from_user_input
+    ):
+        pyramid_request.path = "/https://example.org"
+        url_from_user_input.side_effect = ["https://normalized.com"]
+
+        proxy(pyramid_request)
+
+        url_from_user_input.assert_called_with("https://example.org")
+        get_url_details.assert_called_once_with("https://normalized.com")
+        via_client_service.url_for.assert_called_once_with(
+            "https://normalized.com", sentinel.mime_type, pyramid_request.params
+        )
+
     @pytest.fixture(autouse=True)
     def get_url_details(self, patch):
         get_url_details = patch("via.views.proxy.get_url_details")
         get_url_details.return_value = (sentinel.mime_type, sentinel.status_code)
         return get_url_details
+
+    @pytest.fixture(autouse=True)
+    def url_from_user_input(self, patch):
+        url_from_user_input = patch("via.views.proxy.url_from_user_input")
+        url_from_user_input.side_effect = lambda url: url
+        return url_from_user_input

--- a/via/views/_helpers.py
+++ b/via/views/_helpers.py
@@ -1,0 +1,14 @@
+def url_from_user_input(url):
+    """Return a normalized URL from user input.
+
+    Take a URL from user input (eg. a URL input field or path parameter) and
+    convert it to a normalized form.
+    """
+    url = url.strip()
+    if not url:
+        return url
+
+    if not (url.startswith("http://") or url.startswith("https://")):
+        url = "https://" + url
+
+    return url

--- a/via/views/index.py
+++ b/via/views/index.py
@@ -1,5 +1,10 @@
+from urllib.parse import urlparse
+
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.view import view_config, view_defaults
+
+from via.views._helpers import url_from_user_input
+from via.views.exceptions import BadURL
 
 
 @view_defaults(route_name="index")
@@ -22,8 +27,15 @@ class IndexViews:
         if not self.enabled:
             return HTTPNotFound()
 
+        url = url_from_user_input(self.request.params.get("url", ""))
+        try:
+            parsed = urlparse(url)
+        except ValueError as ex:
+            raise BadURL(url) from ex
+        url_without_query = parsed._replace(query="", fragment="").geturl()
+
         return HTTPFound(
             self.request.route_url(
-                route_name="proxy", url=self.request.params.get("url", "")
+                route_name="proxy", url=url_without_query, _query=parsed.query
             )
         )

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -2,16 +2,13 @@ from pyramid.view import view_config
 
 from via.get_url import get_url_details
 from via.services import ViaClientService
+from via.views._helpers import url_from_user_input
 
 
 @view_config(route_name="proxy", renderer="via:templates/proxy.html.jinja2")
 def proxy(request):
-    url = request.path[1:]  # Strip the leading "/" from the path.
-
-    # Let people just type in "example.com" or link to
-    # via.hypothes.is/example.com and have that proxy https://example.com.
-    if not (url.startswith("http://") or url.startswith("https://")):
-        url = "https://" + url
+    # Strip leading '/' and normalize URL.
+    url = url_from_user_input(request.path[1:])
 
     mime_type, _status_code = get_url_details(url)
 


### PR DESCRIPTION
This PR fixes two issues on the index page:

- Leading or trailing whitespace in the input URL would cause an error when submitting the form
- Query string params in the URL on the index page were not handled correctly when generating the redirect URL: Submitting the URL `https://example.com?param=value` resulted in a redirect to `/https://example.com%3Fparam=value` instead of `/https://example.com?param=value`

Changes in this PR:

- Introduce a `url_from_user_input` helper in `via.views._helpers` that takes URLs from a "user input source" (eg. the `<URL>` part of a manually entered `https://via.hypothes.is/<URL>` input in URL bar, or the URL entered into the input box on the index page) and returns a normalized version that is suitable for passing to `requests` or ViaHTML. The normalized version strips leading/trailing whitespace and adds an `https://` protocol if missing
- On the index page, feed the input URL into `url_from_user_input` and then parse the result to separate out the parts before and after the query. The parts before are passed as the `url` path param when generating the redirect URL for the `proxy` view and the query params are passed as the `_query` to `route_url`

A side effect of these changes is that submitting `example.com` on the homepage will now redirect to `/https://example.com` instead of `/example.com` because the redirect URL is the normalized version.

Fixes https://github.com/hypothesis/via3/issues/482
Fixes https://github.com/hypothesis/via3/issues/479