### PR TITLE
Increase secure link expiry time from 1-2 hours to 24-25 hours

### DIFF
--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -22,7 +22,7 @@ class TestViewPDF:
     def test_it_signs_the_url(self, call_view_pdf, quantized_expiry):
         response = call_view_pdf("https://example.com/foo/bar.pdf?q=s")
 
-        quantized_expiry.assert_called_once_with(max_age=timedelta(hours=2))
+        quantized_expiry.assert_called_once_with(max_age=timedelta(hours=25))
         signed_url = response["proxy_pdf_url"]
         signed_url_parts = signed_url.split("/")
         signature = signed_url_parts[5]

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -49,7 +49,7 @@ def _pdf_url(url, nginx_server, secret):
     """Return the URL from which the PDF viewer should load the PDF."""
 
     # Compute the expiry time to put into the URL.
-    exp = int(quantized_expiry(max_age=timedelta(hours=2)).timestamp())
+    exp = int(quantized_expiry(max_age=timedelta(hours=25)).timestamp())
 
     # The expression to be hashed.
     #


### PR DESCRIPTION
Increase the range of times for which secure links to PDFs are valid
from 1-2 hours to 24-25 hours. We want to see how this affects edge cache
(Cloudflare) hit rates.

As a recap, the main function of secure links in Via is to ensure that only PDF
URLs that have been vetted by Checkmate (or other URL validation/checks) can be
fetched through the proxy. The role of link expiry is to reduce the amount of
time that any generated links remain valid after they become blocked through
these mechanisms. Increasing the expiry time trades off improved downstream
cache hit rates (in Cloudflare, the browser) against longer times for
pre-existing links to recently-blocked URLs remaining accessible.