### PR TITLE
Add stringification to our requests based exceptions for Sentry

### DIFF
--- a/tests/common/requests_exceptions.py
+++ b/tests/common/requests_exceptions.py
@@ -1,0 +1,22 @@
+import json
+from io import BytesIO
+
+from requests import Response
+
+
+def make_requests_exception(
+    error_class, status_code, json_data=None, raw_data=None, **response_kwargs
+):
+    response = Response()
+    response.status_code = status_code
+
+    for key, value in response_kwargs.items():
+        setattr(response, key, value)
+
+    if raw_data:
+        response.raw = BytesIO(raw_data.encode("utf-8"))
+
+    elif json_data:
+        response.raw = BytesIO(json.dumps(json_data).encode("utf-8"))
+
+    return error_class(response=response)

--- a/tests/unit/via/exceptions_test.py
+++ b/tests/unit/via/exceptions_test.py
@@ -1,0 +1,40 @@
+import pytest
+from requests.exceptions import HTTPError
+
+from tests.common.requests_exceptions import make_requests_exception
+from via.exceptions import RequestBasedException
+
+
+class TestRequestBasedException:
+    @pytest.mark.parametrize(
+        "error_params,expected_string",
+        (
+            (
+                {
+                    "status_code": 400,
+                    "reason": "Bad request",
+                    "json_data": {"test": "data", "more": "data"},
+                },
+                'message: 400 Bad request {"test": "data", "more": "data"}',
+            ),
+            (
+                {
+                    "status_code": 401,
+                    "raw_data": "<html>HTML response text!</html>",
+                },
+                "message: 401 <html>HTML response text!</html>",
+            ),
+            (
+                {
+                    "status_code": 402,
+                },
+                "message: 402",
+            ),
+        ),
+    )
+    def test_it(self, error_params, expected_string):
+        exception = RequestBasedException(
+            "message", requests_err=make_requests_exception(HTTPError, **error_params)
+        )
+
+        assert str(exception) == expected_string

--- a/tests/unit/via/services/google_drive_test.py
+++ b/tests/unit/via/services/google_drive_test.py
@@ -1,5 +1,4 @@
 import json
-from io import BytesIO
 from unittest.mock import sentinel
 
 import importlib_resources
@@ -7,9 +6,10 @@ import pytest
 from h_matchers import Any
 from pyramid.httpexceptions import HTTPNotFound
 from pytest import param
-from requests import Response, TooManyRedirects
+from requests import TooManyRedirects
 from requests.exceptions import HTTPError, InvalidJSONError
 
+from tests.common.requests_exceptions import make_requests_exception
 from via.exceptions import (
     ConfigurationError,
     GoogleDriveServiceError,
@@ -267,16 +267,3 @@ class TestGoogleDriveAPI:
     @pytest.fixture(autouse=True)
     def Credentials(self, patch):
         return patch("via.services.google_drive.Credentials")
-
-
-def make_requests_exception(error_class, status_code, json_data=None, raw_data=None):
-    response = Response()
-    response.status_code = status_code
-
-    if raw_data:
-        response.raw = BytesIO(raw_data.encode("utf-8"))
-
-    elif json_data:
-        response.raw = BytesIO(json.dumps(json_data).encode("utf-8"))
-
-    return error_class(response=response)

--- a/via/exceptions.py
+++ b/via/exceptions.py
@@ -7,6 +7,29 @@ class RequestBasedException(Exception):
         self.request = requests_err.request if requests_err else None
         self.response = requests_err.response if requests_err else None
 
+    def __str__(self):
+        string = super().__str__()
+
+        if self.response is None:
+            return string
+
+        # Log the details of the response. This goes to both Sentry and the
+        # application's logs. It's helpful for debugging to know how the
+        # external service responded.
+
+        return " ".join(
+            [
+                part
+                for part in [
+                    f"{string}:",
+                    str(self.response.status_code or ""),
+                    self.response.reason,
+                    self.response.text,
+                ]
+                if part
+            ]
+        )
+
 
 class BadURL(RequestBasedException):
     """An invalid URL was discovered."""


### PR DESCRIPTION
For: 

 * https://github.com/hypothesis/via/issues/641

## Testing notes

 * Hack `via/services/google_drive.py` to crash
 * Try adding nonsense to the end of the URL in `iter_file`
 * Copy the DSN value from: https://sentry.io/settings/hypothesis/projects/sentry-test-environment/keys/
 * `SENTRY_DSN=<dsn-here> make dev`
 * Visit: http://localhost:9083/https://drive.google.com/uc?id=0B358dmxa8_owZ2p0S0loQW9zSFU&export=download
 * You should see the string in the log output
 * You should see the string at: https://sentry.io/organizations/hypothesis/issues/?project=5952630