### PR TITLE
Proxy MS OneDrive PDFs in a python view

### DIFF
--- a/tests/unit/via/services/pdf_url_test.py
+++ b/tests/unit/via/services/pdf_url_test.py
@@ -77,6 +77,30 @@ class TestPDFURLBuilder:
         secure_link_service.sign_url.assert_called_once_with(url)
         assert pdf_url == secure_link_service.sign_url.return_value
 
+    @pytest.mark.parametrize(
+        "url,endpoint_url",
+        (
+            # pylint:disable=line-too-long
+            (
+                "https://my-sharepoint.sharepoint.com/FILE_ID/?download=1",
+                "http://example.com/onedrive/proxied.pdf?url=https%3A%2F%2Fmy-sharepoint.sharepoint.com%2FFILE_ID%2F%3Fdownload%3D1",
+            ),
+            (
+                "https://api.onedrive.com/v1.0/FILE_ID/root/content",
+                "http://example.com/onedrive/proxied.pdf?url=https%3A%2F%2Fapi.onedrive.com%2Fv1.0%2FFILE_ID%2Froot%2Fcontent",
+            ),
+        ),
+    )
+    def test_onedrive_url(
+        self, svc, secure_link_service, google_drive_api, url, endpoint_url
+    ):
+        google_drive_api.parse_file_url.return_value = None
+
+        pdf_url = svc.get_pdf_url(url)
+
+        secure_link_service.sign_url.assert_called_once_with(endpoint_url)
+        assert pdf_url == secure_link_service.sign_url.return_value
+
     def test_nginx_file_url(self, google_drive_api, svc):
         google_drive_api.parse_file_url.return_value = None
 

--- a/via/views/__init__.py
+++ b/via/views/__init__.py
@@ -20,6 +20,12 @@ def add_routes(config):  # pragma: no cover
         "/google_drive/{file_id}/{resource_key}/proxied.pdf",
         factory=QueryURLResource,
     )
+    config.add_route(
+        "proxy_onedrive_pdf",
+        "/onedrive/proxied.pdf",
+        factory=QueryURLResource,
+    )
+
     config.add_route("proxy", "/{url:.*}", factory=PathURLResource)
 
 


### PR DESCRIPTION
Part of: https://github.com/hypothesis/lms/issues/3256

# Testing notes

URLs: 
- one drive `https://api.onedrive.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2IvcyFBaU9PUWVsRWNZS3diZnVvb3JRdmNYYnR2cjQ/root/content`

- sharepoint `https://listhypothesis-my.sharepoint.com/:b:/g/personal/eng_list_hypothes_is/EQS1fwBTvJRJkgiKu_qz-oIBce4F4t2zIWdSVWSMF2MEOg?e=TLbqHg&download=1`

Try to proxy both on http://localhost:9083/

On `master` one drive url gets proxied, sharepoint one fails. On this branch both are successful.
