### PR TITLE
Make raise_for_status optional in HTTPService

### DIFF
--- a/tests/unit/via/get_url_test.py
+++ b/tests/unit/via/get_url_test.py
@@ -40,7 +40,12 @@ class TestGetURLDetails:
 
         assert result == (mime_type, status_code)
         http_service.get.assert_called_once_with(
-            url, allow_redirects=True, stream=True, headers=Any(), timeout=10
+            url,
+            allow_redirects=True,
+            stream=True,
+            headers=Any(),
+            timeout=10,
+            raise_for_status=False,
         )
 
     @pytest.mark.usefixtures("response")

--- a/tests/unit/via/services/http_test.py
+++ b/tests/unit/via/services/http_test.py
@@ -127,6 +127,18 @@ class TestHTTPService:
             {"status_code": status}
         )
 
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 500])
+    def test_it_doesnt_raise_if_the_response_is_an_error_when_disabled(
+        self, svc, url, status
+    ):
+        httpretty.register_uri("GET", url, status=status)
+
+        response = svc.request("GET", url, raise_for_status=False)
+
+        assert response == Any.instance_of(requests.Response).with_attrs(
+            {"status_code": status}
+        )
+
     @pytest.mark.parametrize("request_exception,expected_exception", EXCEPTION_MAP)
     def test_request_with_error_translator_defaults(
         self,

--- a/via/get_url.py
+++ b/via/get_url.py
@@ -32,6 +32,7 @@ def get_url_details(http_service, url, headers=None):
         allow_redirects=True,
         headers=headers,
         timeout=10,
+        raise_for_status=False,
     ) as rsp:
         content_type = rsp.headers.get("Content-Type")
         if content_type:

--- a/via/services/http.py
+++ b/via/services/http.py
@@ -49,7 +49,7 @@ class HTTPService:
     def delete(self, *args, **kwargs):
         return self.request("DELETE", *args, **kwargs)
 
-    def request(self, method, url, timeout=(10, 10), **kwargs):
+    def request(self, method, url, timeout=(10, 10), raise_for_status=True, **kwargs):
         """Send a request with `requests` and return the requests.Response object.
 
         :param method: The HTTP method to use, one of "GET", "PUT", "POST",
@@ -65,6 +65,7 @@ class HTTPService:
             Note that the read_timeout is *not* a time limit on the entire
             response download. It's a time limit on how long to wait *between
             bytes from the server*. The entire download can take much longer.
+        :param raise_for_status: Optionally raise for 4xx & 5xx response statuses.
         :param kwargs: Any other keyword arguments will be passed directly to
             requests.Session().request():
             https://docs.python-requests.org/en/latest/api/#requests.Session.request
@@ -82,7 +83,8 @@ class HTTPService:
                 timeout=timeout,
                 **kwargs,
             )
-            response.raise_for_status()
+            if raise_for_status:
+                response.raise_for_status()
 
         except Exception as err:
             if mapped_err := self._translate_exception(err):


### PR DESCRIPTION
`get_url_details` is ok with 4xx and 5xx responses but HTTPService.request did raise_for_status by default.


Testing

- On the `http-service` branch, proxy https://h.readthedocs.io/_/downloads/en/latest/pdf/
from http://localhost:9083/

   There will be a lot of noise around a favicon.ico failed (404) request which will be translated to an underhanded exception.

- On this branch, testing the same thing logs just this: 

   ```2021-10-29 10:03:18,667 DEBUG [urllib3.connectionpool:452][MainThread] https://h.readthedocs.io:443 "GET /_/downloads/en/latest/pdf/favicon.ico HTTP/1.1" 404 None``` 
