### PR TITLE
Sync transcript immediately after playback starts

### DIFF
--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -104,6 +104,15 @@ export default function VideoPlayerApp({
     []
   );
 
+  // If we transition from paused to playing while autoscroll is active,
+  // immediately scroll the current segment into view. Without this, the
+  // transcript will not scroll until playback reaches the next segment.
+  useEffect(() => {
+    if (autoScroll && playing) {
+      syncTranscript();
+    }
+  }, [autoScroll, playing, syncTranscript]);
+
   // Handle app-wide keyboard shortcuts.
   useEffect(() => {
     const keyListener = (e: KeyboardEvent) => {

--- a/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
+++ b/via/static/scripts/video_player/components/test/VideoPlayerApp-test.js
@@ -196,7 +196,7 @@ describe('VideoPlayerApp', () => {
     assert.equal(player.prop('time'), transcriptData.segments[1].start);
   });
 
-  it('scrolls current transcript segment into view when "Sync" button is clicked', () => {
+  it('syncs transcript when "Sync" button is clicked', () => {
     const wrapper = mount(
       <VideoPlayerApp
         videoId="1234"
@@ -211,6 +211,47 @@ describe('VideoPlayerApp', () => {
     wrapper.find('button[data-testid="sync-button"]').simulate('click');
 
     assert.calledOnce(transcriptController.current.scrollToCurrentSegment);
+  });
+
+  const toggleAutoScroll = wrapper => {
+    act(() => {
+      const input = wrapper.find('input[data-testid="autoscroll-checkbox"]');
+
+      input.getDOMNode().checked = !input.getDOMNode().checked;
+      input.simulate('change');
+    });
+    wrapper.update();
+  };
+
+  const togglePlaying = wrapper => {
+    wrapper.find('button[data-testid="play-button"]').simulate('click');
+  };
+
+  it('syncs transcript when transitioning from paused to playing if auto-scroll is active', () => {
+    const wrapper = mount(
+      <VideoPlayerApp
+        videoId="1234"
+        clientSrc="https://dummy.hypothes.is/embed.js"
+        clientConfig={{}}
+        transcript={transcriptData}
+      />
+    );
+    const transcriptController = wrapper.find('Transcript').prop('controlsRef');
+    assert.ok(transcriptController.current);
+
+    // When auto-scroll is active (default state) transcript should sync as
+    // soon as playback starts.
+    togglePlaying(wrapper);
+    assert.calledOnce(transcriptController.current.scrollToCurrentSegment);
+    transcriptController.current.scrollToCurrentSegment.resetHistory();
+
+    togglePlaying(wrapper); // Pause video
+
+    // If auto-scroll is disabled when the play button is clicked, it shouldn't
+    // sync.
+    toggleAutoScroll(wrapper);
+    togglePlaying(wrapper);
+    assert.notCalled(transcriptController.current.scrollToCurrentSegment);
   });
 
   function setFilter(wrapper, query) {
@@ -292,20 +333,10 @@ describe('VideoPlayerApp', () => {
       />
     );
 
-    const toggleAutoScroll = () => {
-      act(() => {
-        const input = wrapper.find('input[data-testid="autoscroll-checkbox"]');
-
-        input.getDOMNode().checked = !input.getDOMNode().checked;
-        input.simulate('change');
-      });
-      wrapper.update();
-    };
-
     assert.isTrue(wrapper.find('Transcript').prop('autoScroll'));
-    toggleAutoScroll();
+    toggleAutoScroll(wrapper);
     assert.isFalse(wrapper.find('Transcript').prop('autoScroll'));
-    toggleAutoScroll();
+    toggleAutoScroll(wrapper);
     assert.isTrue(wrapper.find('Transcript').prop('autoScroll'));
   });
 


### PR DESCRIPTION
When autoscroll is active, sync the transcript immediately after the video starts playing. Previously the transcript did not sync until playback reached the start of the next segment after the current one.

**Testing:**

1. Go to a video (eg. http://localhost:9083/video/x8TO-nrUtSI)
2. Scroll the transcript down
3. Start playing the video by any of the available means (clicking in the player, pressing the "Play" button, pressing the "k" shortcut)

At step 3, the transcript should immediately scroll to the current location. On `main` it won't scroll few a few seconds until playback reaches the next segment.

If the "auto-scroll" checkbox is unchecked, this scroll-on-play behavior shouldn't happen.