### PR TITLE
Add YouTube support to public Via and LMS

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -63,7 +63,7 @@ h-assets==1.0.5
     # via -r requirements/prod.txt
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
-h-vialib==1.2.0
+h-vialib==1.2.1
     # via -r requirements/prod.txt
 hupper==1.10.2
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -61,7 +61,7 @@ h-matchers==1.2.15
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
-h-vialib==1.2.0
+h-vialib==1.2.1
     # via -r requirements/prod.txt
 httpretty==1.1.4
     # via -r requirements/functests.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -105,7 +105,7 @@ h-pyramid-sentry==1.2.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-h-vialib==1.2.0
+h-vialib==1.2.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -32,7 +32,7 @@ h-assets==1.0.5
     # via -r requirements/prod.in
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.in
-h-vialib==1.2.0
+h-vialib==1.2.1
     # via -r requirements/prod.in
 hupper==1.10.2
     # via pyramid

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -63,7 +63,7 @@ h-matchers==1.2.15
     # via -r requirements/tests.in
 h-pyramid-sentry==1.2.4
     # via -r requirements/prod.txt
-h-vialib==1.2.0
+h-vialib==1.2.1
     # via -r requirements/prod.txt
 httpretty==1.1.4
     # via -r requirements/tests.in

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -56,4 +56,7 @@ def pdf_url_builder_service(mock_service):
 
 @pytest.fixture
 def youtube_service(mock_service):
-    return mock_service(YouTubeService)
+    youtube_service = mock_service(YouTubeService)
+    youtube_service.enabled = True
+    youtube_service.get_video_id.return_value = None
+    return youtube_service

--- a/tests/unit/via/services/url_details_test.py
+++ b/tests/unit/via/services/url_details_test.py
@@ -72,9 +72,31 @@ class TestGetURLDetails:
         GoogleDriveAPI.parse_file_url.assert_called_once_with(sentinel.google_drive_url)
         http_service.get.assert_not_called()
 
+    def test_it_returns_youtube_for_youtube_url(
+        self, http_service, youtube_service, GoogleDriveAPI, svc
+    ):
+        GoogleDriveAPI.parse_file_url.return_value = {}
+        youtube_service.get_video_id.return_value = "VIDEO_ID"
+
+        result = svc.get_url_details(sentinel.youtube_url)
+
+        youtube_service.get_video_id.assert_called_once_with(sentinel.youtube_url)
+        http_service.get.assert_not_called()
+        assert result == ("video/x-youtube", 200)
+
+    @pytest.mark.usefixtures("response")
+    def test_it_when_youtube_disabled(self, youtube_service, GoogleDriveAPI, svc):
+        GoogleDriveAPI.parse_file_url.return_value = {}
+        youtube_service.enabled = False
+
+        result = svc.get_url_details(sentinel.youtube_url)
+
+        youtube_service.get_video_id.assert_not_called()
+        assert result == ("dummy", 200)
+
     @pytest.fixture
-    def svc(self, http_service):
-        return URLDetailsService(http_service)
+    def svc(self, http_service, youtube_service):
+        return URLDetailsService(http_service, youtube_service)
 
     @pytest.fixture
     def response(self, http_service):
@@ -99,7 +121,7 @@ class TestGetURLDetails:
         return patch("via.services.url_details.clean_headers", return_value={})
 
 
-@pytest.mark.usefixtures("http_service")
+@pytest.mark.usefixtures("http_service", "youtube_service")
 def test_factory(pyramid_request):
     svc = factory(sentinel.context, pyramid_request)
 

--- a/tests/unit/via/services/via_client_test.py
+++ b/tests/unit/via/services/via_client_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
+from h_vialib import ContentType
 
 from via.services.via_client import ViaClientService, factory
 
@@ -9,9 +10,10 @@ class TestViaClientService:
     @pytest.mark.parametrize(
         "mime_type,expected_content_type",
         [
-            ("application/x-pdf", "pdf"),
-            ("application/pdf", "pdf"),
-            ("text/html", "html"),
+            ("application/x-pdf", ContentType.PDF),
+            ("application/pdf", ContentType.PDF),
+            ("text/html", ContentType.HTML),
+            ("video/x-youtube", ContentType.YOUTUBE),
         ],
     )
     def test_content_type(self, mime_type, expected_content_type, svc):
@@ -20,9 +22,9 @@ class TestViaClientService:
     @pytest.mark.parametrize(
         "mime_type,expected_content_type",
         [
-            ("application/pdf", "pdf"),
-            ("text/html", "html"),
-            (None, "html"),
+            ("application/pdf", ContentType.PDF),
+            ("text/html", ContentType.HTML),
+            (None, ContentType.HTML),
         ],
     )
     def test_url_for(self, mime_type, expected_content_type, svc, via_client):

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import create_autospec, sentinel
 
 import pytest
+from h_vialib import ContentType
 
 from tests.conftest import assert_cache_control
 from tests.unit.matchers import temporary_redirect_to
@@ -13,12 +14,17 @@ class TestRouteByContent:
     @pytest.mark.parametrize(
         "content_type,status_code,expected_cache_control_header",
         [
-            ("pdf", 200, "public, max-age=300, stale-while-revalidate=86400"),
-            ("html", 200, "public, max-age=60, stale-while-revalidate=86400"),
-            ("html", 401, "public, max-age=60, stale-while-revalidate=86400"),
-            ("html", 404, "public, max-age=60, stale-while-revalidate=86400"),
-            ("html", 500, "no-cache"),
-            ("html", 501, "no-cache"),
+            (ContentType.PDF, 200, "public, max-age=300, stale-while-revalidate=86400"),
+            (
+                ContentType.YOUTUBE,
+                200,
+                "public, max-age=300, stale-while-revalidate=86400",
+            ),
+            (ContentType.HTML, 200, "public, max-age=60, stale-while-revalidate=86400"),
+            (ContentType.HTML, 401, "public, max-age=60, stale-while-revalidate=86400"),
+            (ContentType.HTML, 404, "public, max-age=60, stale-while-revalidate=86400"),
+            (ContentType.HTML, 500, "no-cache"),
+            (ContentType.HTML, 501, "no-cache"),
         ],
     )
     def test_it(

--- a/via/services/via_client.py
+++ b/via/services/via_client.py
@@ -1,17 +1,18 @@
 """A thin wrapper around ViaClient to make it a service."""
-from h_vialib import ViaClient
+from h_vialib import ContentType, ViaClient
 
 
 class ViaClientService:
     """A wrapper service for h_vialib.ViaClient."""
 
     _mime_types_content_type = {
-        "application/x-pdf": "pdf",
-        "application/pdf": "pdf",
+        "application/x-pdf": ContentType.PDF,
+        "application/pdf": ContentType.PDF,
+        "video/x-youtube": ContentType.YOUTUBE,
     }
 
     def content_type(self, mime_type):
-        return self._mime_types_content_type.get(mime_type, "html")
+        return self._mime_types_content_type.get(mime_type, ContentType.HTML)
 
     def __init__(self, via_client):
         self.via_client = via_client

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -1,5 +1,6 @@
 """View for redirecting based on content type."""
 
+from h_vialib import ContentType
 from pyramid import httpexceptions as exc
 from pyramid import view
 
@@ -18,7 +19,7 @@ def route_by_content(context, request):
     )
     via_client_svc = request.find_service(ViaClientService)
 
-    if via_client_svc.content_type(mime_type) == "pdf":
+    if via_client_svc.content_type(mime_type) in (ContentType.PDF, ContentType.YOUTUBE):
         caching_headers = _caching_headers(max_age=300)
     else:
         caching_headers = _cache_headers_for_http(status_code)


### PR DESCRIPTION
Make the Via front page (used by public Via) and the `/route` endpoint (used by LMS when it doesn't already know the content-type of the document and wants Via to figure it out) redirect users to the new YouTube transcript annotation app at `/video/youtube` if given a YouTube URL.

This gets YouTube support working for public Via's front page (if you paste in a YouTube URL you'll get sent to the new YouTube app) and LMS (if you use the **URL** picker when creating an assignment, **not** the new YouTube picker, and paste in a YouTube URL then the assignment will use the new YouTube app).

There are a few parts to this:
    
* Upgrade to h-vialib 1.2.1 in order to get https://github.com/hypothesis/h-vialib/pull/55
    
* `URLDetailsService.get_url_details()` now returns `"video/x-youtube"` as the MIME type if the given URL is a YouTube URL. This is called by `proxy.py` and `route_by_content.py` to get the MIME type. They both then pass the MIME type to `ViaClientService.url_for()`...
    
* `ViaClientService.content_type()` now returns `"youtube"` if the given MIME type is one of the new `"video/x-youtube"` ones that `URLDetailsService` now returns. `content_type()` gets called by `ViaClientService`'s own `url_for()` method which passes the resulting `"youtube"` content type to `h_vialib.ViaClient.url_for()` which, if given `"youtube"` for the content type, generates a `"/video/youtube"` Via URL. `proxy.py` and `route_by_content.py` both call this `url_for()` method in order to generate the URL to be used for viewing the document.
    
* `route_by_content.py` applies the same caching headers to its redirects to `/video/youtube` URLs as it does to `/pdf` URLs

## Testing

* Go to <http://localhost:9083/> and paste in a YouTube URL, for example <http://localhost:9083/https://www.youtube.com/watch?v=8uM2UhCkS-s>. You'll get the new YouTube app.
* Try some none-YouTube URLs and you'll get the normal HTML or PDF annotation. For example:
  * HTML: http://localhost:9083/https://example.com/
  * PDF: http://localhost:9083/https://h.readthedocs.io/_/downloads/en/latest/pdf/
* Create an LMS assignment and select the plain **URL** picker (**not** the new YouTube picker) and paste in a YouTube URL (example: https://www.youtube.com/watch?v=8uM2UhCkS-s) and your assignment will use the new YouTube app
* If you disable the `YOUTUBE_TRANSCRIPTS` feature flag and visit <http://localhost:9083/https://www.youtube.com/watch?v=8uM2UhCkS-s> you'll get the normal HTML page annotation. Also if you load your LMS YouTube assignment. In fish shell: `set -x YOUTUBE_TRANSCRIPTS false`