### PR TITLE
Add Checkmate to `view_video()`

### DIFF
--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -24,6 +24,8 @@ def youtube(request, url, **kwargs):
     if not video_id:
         raise BadURL(f"Unsupported video URL: {url}", url=url)
 
+    request.checkmate.raise_if_blocked(url)
+
     _, client_config = Configuration.extract_from_params(kwargs)
 
     return {


### PR DESCRIPTION
URLs like `https://via.hypothes.is/video/youtube?url=<YOUTUBE_URL>` can be visited directly by users or might be embedded directly by LMS and would proxy a YouTube video even if that video were blocked by Checkmate.

Add a Checkmate call to the `view_video()` route so that these URLs will error if given a YouTube video that's blocked by Checkmate.

Fixes https://github.com/hypothesis/via/issues/978

I haven't tested this manually because I don't know of an easy way to add a URL to Checkmate's blocklist (and it doesn't seem to be documented in Checkmate's README).