### PR TITLE
Provide right-channel buckets styling for all layouts

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,6 +17,11 @@ export default {
           'sans-serif',
         ],
       },
+      boxShadow: {
+        // Similar to tailwind's default `shadow-inner` but coming from the
+        // right edge instead of the left
+        'r-inner': 'inset -2px 0 4px 0 rgb(0,0,0,.05)',
+      },
     },
   },
 };

--- a/via/static/scripts/video_player/components/Transcript.tsx
+++ b/via/static/scripts/video_player/components/Transcript.tsx
@@ -1,6 +1,6 @@
 import { Scroll, ScrollContainer } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import type { Ref } from 'preact';
+import type { ComponentChildren, Ref } from 'preact';
 import {
   useCallback,
   useEffect,
@@ -31,6 +31,11 @@ export type TranscriptProps = {
    * the segment corresponding to `currentTime` in view.
    */
   autoScroll?: boolean;
+
+  /** Other content to render in scrolling container after the transcript
+   * segments.
+   */
+  children?: ComponentChildren;
 
   transcript: TranscriptData;
 
@@ -182,14 +187,14 @@ function TranscriptSegment({
       />
       <p
         className={classnames(
-          'grow text-justify peer-hover:text-stone-900',
+          'grow peer-hover:text-stone-900',
           {
             'text-stone-600': !isCurrent,
             'text-stone-800': isCurrent,
           },
 
           // Avoid buckets overlapping highlighted text.
-          'pr-[30px]'
+          'pr-3'
         )}
         data-testid="transcript-text"
         ref={contentRef}
@@ -222,6 +227,7 @@ function offsetRelativeTo(element: HTMLElement, parent: HTMLElement): number {
 
 export default function Transcript({
   autoScroll = true,
+  children,
   controlsRef,
   currentTime,
   filter = '',
@@ -337,24 +343,27 @@ export default function Transcript({
         data-testid="scroll-container"
         elementRef={scrollRef}
       >
-        <ul>
-          {transcript.segments.map((segment, index) => (
-            <TranscriptSegment
-              key={index}
-              hidden={
-                filterMatches
-                  ? !filterMatches.has(index) && index !== currentIndex
-                  : false
-              }
-              highlight={highlight}
-              isCurrent={index === currentIndex}
-              matches={filterMatches?.get(index)}
-              onSelect={() => onSelectSegment?.(segment)}
-              time={segment.start}
-              text={segment.text}
-            />
-          ))}
-        </ul>
+        <div className="flex">
+          <ul className="grow shadow-r-inner">
+            {transcript.segments.map((segment, index) => (
+              <TranscriptSegment
+                key={index}
+                hidden={
+                  filterMatches
+                    ? !filterMatches.has(index) && index !== currentIndex
+                    : false
+                }
+                highlight={highlight}
+                isCurrent={index === currentIndex}
+                matches={filterMatches?.get(index)}
+                onSelect={() => onSelectSegment?.(segment)}
+                time={segment.start}
+                text={segment.text}
+              />
+            ))}
+          </ul>
+          {children}
+        </div>
       </Scroll>
     </ScrollContainer>
   );

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -229,14 +229,18 @@ export default function VideoPlayerApp({
   return (
     <div
       data-testid="app-container"
-      className="flex flex-col h-[100vh] min-h-0"
+      className={classnames(
+        'flex flex-col h-[100vh] min-h-0',
+        // Leave room for the sidebar toolbar/bucket-bar channel on the right
+        'mr-[20px]'
+      )}
     >
       {multicolumn && (
         <div
           data-testid="top-bar"
           className={classnames(
             'h-[40px] min-h-[40px] w-full flex items-center gap-x-3',
-            'px-2 border-b bg-grey-0'
+            'pl-2 border-b bg-grey-0'
           )}
         >
           <HypothesisLogo />
@@ -245,8 +249,10 @@ export default function VideoPlayerApp({
             data-testid="filter-container"
             className={classnames(
               'text-right',
-              // TODO: Temporary prevention of sidebar controls overlapping
-              'mr-[22px]'
+              // Put space to the right of the filter input so it is not
+              // overlaid by sidebar controls. NB: Cannot use margin because it
+              // gets "consumed" in side-by-side mode
+              'pr-4'
             )}
             style={{ width: transcriptWidths[appSize] }}
           >
@@ -302,9 +308,6 @@ export default function VideoPlayerApp({
             // Make transcript fill available vertical space in single-column
             // layouts
             'min-h-0 grow': !multicolumn,
-            // TODO: This is a stopgap measure to prevent controls from being
-            // interfered with (overlaid) by sidebar controls and toolbar
-            'mr-[30px]': multicolumn,
           })}
           style={{ width: transcriptWidths[appSize] }}
         >
@@ -314,11 +317,12 @@ export default function VideoPlayerApp({
               // Same height as top-bar
               'h-[40px] min-h-[40px]',
               'bg-grey-1 flex items-center',
-              // TODO: This is a stopgap measure to prevent the right side of the
-              // transcript controls from being inpinged on by sidebar controls
-              'pr-2',
               {
+                // Provide the correct right alignment with the sidebar
+                // Multicolumn needs more right-hand space to avoid interference
+                // by sidebar controls
                 'px-1.5': !multicolumn,
+                'pr-4': multicolumn,
               }
             )}
           >
@@ -385,7 +389,17 @@ export default function VideoPlayerApp({
               currentTime={timestamp}
               filter={trimmedFilter}
               onSelectSegment={segment => setTimestamp(segment.start)}
-            />
+            >
+              <div
+                data-testid="bucket-bar-channel"
+                className={classnames(
+                  // Provide a backdrop for bucket bar buttons. 20px of this
+                  // is overlaid by the sidebar's semi-transparent bucket
+                  // channel.
+                  'bg-gradient-to-r from-white to-grey-1 border-l w-[40px]'
+                )}
+              />
+            </Transcript>
             <div
               id={bucketContainerId}
               className={classnames(
@@ -393,10 +407,17 @@ export default function VideoPlayerApp({
                 // small gap to avoid buckets touching the border.
                 //
                 // The bucket bar width is currently copied from the client.
-                'absolute right-1 top-0 bottom-0 w-[23px]',
+                'absolute right-1.5 bottom-0 w-[23px]',
 
                 // Make the bucket bar fill this container.
-                'flex flex-column'
+                'flex flex-column',
+
+                {
+                  'top-0': !multicolumn,
+                  // Leave room for sidebar toolbar buttons at top of buckets
+                  // in multi-column layouts
+                  'h-[calc(100%-24px)]': multicolumn,
+                }
               )}
             />
           </div>


### PR DESCRIPTION
This PR attempts to solve the problem of space along the right margin and add a channel backdrop for buckets for all layouts. It was a technical challenge!

This is probably the last "messy" applied-design PR before extracting, cleaning up and consolidating layout-related components and logic.

## Multi-column layouts

#### With sidebar closed

**Before**:

<img width="1319" alt="Screen Shot 2023-06-21 at 10 29 07 AM" src="https://github.com/hypothesis/via/assets/439947/a80e61f8-81a8-426a-981a-d843baa9b789">

**After**:
<img width="1325" alt="Screen Shot 2023-06-21 at 10 27 45 AM" src="https://github.com/hypothesis/via/assets/439947/33cee595-ba98-454f-a573-d49802d3f5fe">

#### With sidebar open

**Before**:

<img width="1522" alt="Screen Shot 2023-06-21 at 10 29 16 AM" src="https://github.com/hypothesis/via/assets/439947/eb32a4ab-969e-4d7b-bd11-150438fdc81b">

**After**:
<img width="1619" alt="Screen Shot 2023-06-21 at 10 28 03 AM" src="https://github.com/hypothesis/via/assets/439947/5063c539-c62d-4e98-b01c-ec47ef854ef6">

## Single-column layout

(No change when sidebar open)

**Before**:

<img width="612" alt="Screen Shot 2023-06-21 at 10 29 26 AM" src="https://github.com/hypothesis/via/assets/439947/6ec75f67-9b0d-49c0-b88b-eba6992ebe61">

**After**:

<img width="630" alt="Screen Shot 2023-06-21 at 10 28 14 AM" src="https://github.com/hypothesis/via/assets/439947/f09b3bee-6789-4fd6-84ea-d19db8d282bb">

NB: This may render https://github.com/hypothesis/client/issues/5554 non-applicable as we've solved it in a different way here. It's still a bit of a shame to lose 20px at the right edge in narrow screens, but not a crisis.

Part of https://github.com/hypothesis/via/issues/953