### PR TITLE
Fetch video transcript from API instead of using hard-coded data

### DIFF
--- a/via/static/scripts/test-util/video-player-fixtures.ts
+++ b/via/static/scripts/test-util/video-player-fixtures.ts
@@ -1,0 +1,39 @@
+// Shared fixtures for video player app tests.
+
+/**
+ * Configuration for video player app.
+ */
+export const videoPlayerConfig = {
+  api: {
+    transcript: {
+      doc: 'Get the transcript of the current video',
+      url: 'https://dummy-via.hypothes.is/api/youtube/test_video_id',
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer FAKE_JWT_TOKEN',
+      },
+    },
+  },
+};
+
+/**
+ * Dummy response from transcript API endpoint.
+ */
+export const transcriptsAPIResponse = {
+  data: {
+    type: 'transcripts',
+    id: 'test_video_id',
+    attributes: {
+      segments: [
+        {
+          text: '[Music]',
+          start: 0.0,
+        },
+        {
+          text: 'how many of you remember the first time',
+          start: 5.6,
+        },
+      ],
+    },
+  },
+};

--- a/via/static/scripts/test-util/wait.ts
+++ b/via/static/scripts/test-util/wait.ts
@@ -7,7 +7,7 @@ export async function waitFor<T>(
   condition: () => T,
   timeout = 10,
   what = condition.toString()
-): Promise<T> {
+): Promise<NonNullable<T>> {
   const result = condition();
   if (result) {
     return result;
@@ -28,6 +28,41 @@ export async function waitFor<T>(
       }
     });
   });
+}
+
+// Minimal Enzyme types needed by `waitForElement`.
+
+// eslint-disable-next-line no-use-before-define
+type Predicate = (wrapper: EnzymeWrapper) => boolean;
+
+type EnzymeWrapper = {
+  length: number;
+  update(): void;
+  find(query: string | Predicate): EnzymeWrapper;
+};
+
+/**
+ * Wait up to `timeout` ms for an element to be rendered.
+ *
+ * @param selector - Selector string or function to pass to `wrapper.find`
+ */
+export function waitForElement(
+  wrapper: EnzymeWrapper,
+  selector: string | Predicate,
+  timeout = 10
+): Promise<EnzymeWrapper> {
+  return waitFor(
+    () => {
+      wrapper.update();
+      const el = wrapper.find(selector);
+      if (el.length === 0) {
+        return null;
+      }
+      return el;
+    },
+    timeout,
+    `"${selector}" to render`
+  );
 }
 
 export function delay(ms: number) {

--- a/via/static/scripts/video_player/components/VideoPlayerApp.tsx
+++ b/via/static/scripts/video_player/components/VideoPlayerApp.tsx
@@ -41,7 +41,7 @@ export type VideoPlayerAppProps = {
 
   /**
    * The data source for the transcript. Either an API to call when the player
-   * loads, or pre-fetched data.
+   * loads, or pre-fetched data (mostly useful in tests).
    */
   transcriptSource: APIMethod | TranscriptData;
 };

--- a/via/static/scripts/video_player/config.ts
+++ b/via/static/scripts/video_player/config.ts
@@ -1,4 +1,9 @@
-import type { TranscriptData } from './utils/transcript';
+import type { APIMethod } from './utils/api';
+
+/** Directory of available API methods. */
+export type APIIndex = {
+  transcript: APIMethod;
+};
 
 export type ConfigObject = {
   /** ID of the YouTube video to load. */
@@ -10,8 +15,8 @@ export type ConfigObject = {
   /** URL of the Hypothesis client to load. */
   client_src: string;
 
-  /** Transcript of the video. */
-  transcript: TranscriptData;
+  /** API index. */
+  api: APIIndex;
 };
 
 /**

--- a/via/static/scripts/video_player/index.tsx
+++ b/via/static/scripts/video_player/index.tsx
@@ -5,9 +5,6 @@ import 'preact/debug';
 
 import VideoPlayerApp from './components/VideoPlayerApp';
 import { readConfig } from './config';
-import { sampleTranscript } from './sample-transcript';
-import type { TranscriptData } from './utils/transcript';
-import { mergeSegments } from './utils/transcript';
 
 export function init() {
   const rootEl = document.querySelector('#app');
@@ -16,28 +13,18 @@ export function init() {
   }
 
   const {
+    api,
     client_config: clientConfig,
     client_src: clientSrc,
-
-    // Ignored until backend is able to provide real transcript data.
-    // transcript,
-
     video_id: videoId,
   } = readConfig();
-
-  // Pre-fetched transcript for testing. From the video
-  // https://www.youtube.com/watch?v=x8TO-nrUtSI.
-  const transcript: TranscriptData = { segments: sampleTranscript };
-
-  // Group segments together for better readability.
-  transcript.segments = mergeSegments(transcript.segments, 3);
 
   render(
     <VideoPlayerApp
       videoId={videoId}
       clientConfig={clientConfig}
       clientSrc={clientSrc}
-      transcript={transcript}
+      transcriptSource={api.transcript}
     />,
     rootEl
   );

--- a/via/static/scripts/video_player/utils/api.ts
+++ b/via/static/scripts/video_player/utils/api.ts
@@ -1,0 +1,64 @@
+/** Data needed to call an API method. */
+export type APIMethod = {
+  /** Headers to include with the request. */
+  headers: Record<string, string>;
+
+  /** HTTP method. */
+  method: string;
+
+  /** Endpoint URL. */
+  url: string;
+};
+
+export class APIError extends Error {
+  /** The HTTP status code of the response. */
+  status: number;
+
+  /**
+   * Payload of the response.
+   */
+  data: unknown;
+
+  constructor(status: number, data: unknown) {
+    super('API call failed');
+
+    this.status = status;
+    this.data = data;
+  }
+}
+
+/**
+ * Structure of a JSON API response.
+ *
+ * See https://jsonapi.org/format/#document-structure.
+ */
+export type JSONAPIObject<Properties extends object> = {
+  data: {
+    type: string;
+    id: string;
+    attributes: Properties;
+  };
+};
+
+/**
+ * Make an API call to the backend.
+ *
+ * API request/response formats follow [JSON:API](https://jsonapi.org).
+ */
+export async function callAPI<T = unknown>(api: APIMethod): Promise<T> {
+  const headers = { ...api.headers };
+  headers['Content-Type'] = 'application/json; charset=UTF-8';
+
+  const result = await fetch(api.url, {
+    method: api.method,
+    headers,
+  });
+
+  const resultData = await result.json().catch(() => null);
+
+  if (result.status >= 400 && result.status < 600) {
+    throw new APIError(result.status, resultData);
+  }
+
+  return resultData;
+}

--- a/via/static/scripts/video_player/utils/test/api-test.js
+++ b/via/static/scripts/video_player/utils/test/api-test.js
@@ -1,0 +1,70 @@
+import {
+  videoPlayerConfig,
+  transcriptsAPIResponse,
+} from '../../../test-util/video-player-fixtures';
+import { APIError, callAPI } from '../api';
+
+/**
+ * Create a fake HTTP response with a given status code and JSON body.
+ */
+function jsonResponse(status, body = null) {
+  return new Response(JSON.stringify(body), {
+    status,
+  });
+}
+
+describe('callAPI', () => {
+  let fakeFetch;
+  beforeEach(() => {
+    fakeFetch = sinon.stub(window, 'fetch').resolves(jsonResponse(404));
+  });
+
+  afterEach(() => {
+    window.fetch.restore();
+  });
+
+  it('calls JSON:API method and returns result', async () => {
+    fakeFetch
+      .withArgs(videoPlayerConfig.api.transcript.url)
+      .resolves(jsonResponse(200, transcriptsAPIResponse));
+
+    const result = await callAPI(videoPlayerConfig.api.transcript);
+
+    assert.deepEqual(result, transcriptsAPIResponse);
+  });
+
+  it('throws exception if result is not JSON', async () => {
+    fakeFetch
+      .withArgs(videoPlayerConfig.api.transcript.url)
+      .resolves(new Response('<b>Oh no</b>', { status: 500 }));
+
+    let error;
+    try {
+      await callAPI(videoPlayerConfig.api.transcript);
+    } catch (e) {
+      error = e;
+    }
+
+    assert.instanceOf(error, APIError);
+    assert.equal(error.status, 500);
+    assert.equal(error.data, null);
+    assert.equal(error.message, 'API call failed');
+  });
+
+  it('throws exception if API request fails', async () => {
+    fakeFetch
+      .withArgs(videoPlayerConfig.api.transcript.url)
+      .resolves(jsonResponse(404));
+
+    let error;
+    try {
+      await callAPI(videoPlayerConfig.api.transcript);
+    } catch (e) {
+      error = e;
+    }
+
+    assert.instanceOf(error, APIError);
+    assert.equal(error.status, 404);
+    assert.equal(error.message, 'API call failed');
+  });
+});


### PR DESCRIPTION
Use the API added in https://github.com/hypothesis/via/pull/1000 to fetch video transcripts, instead of hard-coded data. There is currently a known issue where there is a race condition between the client loading and the transcript loading. If the client loads first, it may cause existing annotations to fail to anchor. I will be working to fix that after this lands.

**Summary of changes:**

 - Copy `waitForElement` utility from lms repo, and convert to TypeScript
 - Add types for API responses from the server and `callAPI` utility to make
   calls to API.
 - Change `VideoPlayerApp` component to accept either a pre-fetched transcript
   or API call configuration as the transcript source. If passed an API call
   config, it displays a loading state, performs the API call and then displays
   the response.

   In the actual app an API call is always used, but the pre-fetched transcript
   is useful in tests.

 - Change video player entry point to read API index from JSON configuration and
   pass the config for the transcript API call to `VideoPlayerApp`.

**Testing:**

1. Go to http://localhost:9083/video/youtube?url=https://www.youtube.com/watch?v=x8TO-nrUtSI. The transcript should load as before.
2. Modify the `callAPI` function in `api.ts` to add a delay and/or fail, then refresh the page. You will see a loading spinner followed by a gloriously unstyled error state.

```ts
export async function callAPI<T = unknown>(api: APIMethod): Promise<T> {
  const headers = { ...api.headers };
  headers['Content-Type'] = 'application/json; charset=UTF-8';

  // Added - Simulate delay and eventual error.
  await new Promise(resolve => setTimeout(resolve, 2000));
  throw new APIError(400);
  ...
}
```

<img width="520" alt="Screenshot 2023-06-27 at 13 10 38" src="https://github.com/hypothesis/via/assets/2458/881a9be4-226b-42f2-82ef-96b719d47d9b">

<img width="516" alt="Transcript error state" src="https://github.com/hypothesis/via/assets/2458/7a6932ce-3d5b-46d9-9afe-5c89b3a0b04f">

