### PR TITLE
Block access to Via in the web app 

### DIFF
--- a/tests/functional/api/view_pdf_test.py
+++ b/tests/functional/api/view_pdf_test.py
@@ -3,5 +3,6 @@ class TestViewPDFAPI:
         response = test_app.get("/pdf?url=http://example.com/foo.pdf")
 
         assert response.status_code == 200
-        assert "Access to Via is now restricted" in response.text
+        assert "Access to Via is now" in response.text
+        assert "restricted" in response.text
         assert "http://example.com/foo.pdf" in response.text

--- a/tests/functional/api/view_pdf_test.py
+++ b/tests/functional/api/view_pdf_test.py
@@ -1,13 +1,7 @@
-import pytest
-
-from tests.conftest import assert_cache_control
-
-
 class TestViewPDFAPI:
-    @pytest.mark.usefixtures("checkmate_pass")
-    def test_caching_is_disabled(self, test_app):
+    def test_pdf_shows_restricted_page(self, test_app):
         response = test_app.get("/pdf?url=http://example.com/foo.pdf")
 
-        assert_cache_control(
-            response.headers, ["max-age=0", "must-revalidate", "no-cache", "no-store"]
-        )
+        assert response.status_code == 200
+        assert "Access to Via is now restricted" in response.text
+        assert "http://example.com/foo.pdf" in response.text

--- a/tests/functional/api/views/route_by_content_test.py
+++ b/tests/functional/api/views/route_by_content_test.py
@@ -1,62 +1,9 @@
-from urllib.parse import quote_plus
-
-import httpretty
-import pytest
-from h_matchers import Any
-
-from tests.conftest import assert_cache_control
-
-
 class TestRouteByContent:
-    DEFAULT_OPTIONS = {  # noqa: RUF012
-        "via.client.ignoreOtherConfiguration": "1",
-        "via.client.openSidebar": "1",
-        "via.external_link_mode": "new-tab",
-    }
-
-    @pytest.mark.usefixtures("html_response", "checkmate_pass")
-    def test_proxy_html(self, test_app):
+    def test_route_shows_restricted_page(self, test_app):
         target_url = "http://example.com"
 
         response = test_app.get(f"/route?url={target_url}")
 
-        assert response.status_code == 302
-        query = dict(self.DEFAULT_OPTIONS)
-        assert response.location == Any.url.matching(
-            f"https://viahtml.hypothes.is/proxy/{target_url}/"
-        ).with_query(query)
-
-    @pytest.mark.usefixtures("pdf_response", "checkmate_pass")
-    def test_proxy_pdf(self, test_app):
-        target_url = "http://example.com"
-
-        response = test_app.get(f"/route?url={target_url}")
-
-        assert response.status_code == 302
-        query = dict(self.DEFAULT_OPTIONS)
-        query["via.sec"] = Any.string()
-        query["url"] = target_url
-        assert response.location == Any.url.matching(
-            f"http://localhost/pdf?url={quote_plus(target_url)}"
-        ).with_query(query)
-        assert_cache_control(
-            response.headers, ["public", "max-age=300", "stale-while-revalidate=86400"]
-        )
-
-    @pytest.fixture
-    def html_response(self):
-        httpretty.register_uri(
-            httpretty.GET,
-            "http://example.com",
-            status=204,
-            adding_headers={"Content-Type": "text/html"},
-        )
-
-    @pytest.fixture
-    def pdf_response(self):
-        httpretty.register_uri(
-            httpretty.GET,
-            "http://example.com",
-            status=204,
-            adding_headers={"Content-Type": "application/pdf"},
-        )
+        assert response.status_code == 200
+        assert "Access to Via is now restricted" in response.text
+        assert target_url in response.text

--- a/tests/functional/api/views/route_by_content_test.py
+++ b/tests/functional/api/views/route_by_content_test.py
@@ -5,5 +5,6 @@ class TestRouteByContent:
         response = test_app.get(f"/route?url={target_url}")
 
         assert response.status_code == 200
-        assert "Access to Via is now restricted" in response.text
+        assert "Access to Via is now" in response.text
+        assert "restricted" in response.text
         assert target_url in response.text

--- a/tests/functional/static_content_test.py
+++ b/tests/functional/static_content_test.py
@@ -2,10 +2,12 @@
 
 import re
 
+import importlib_resources
 import pytest
 from h_matchers import Any
 
 from tests.conftest import assert_cache_control
+from via.cache_buster import PathCacheBuster
 
 
 class TestStaticContent:
@@ -48,10 +50,6 @@ class TestStaticContent:
             # The restricted template doesn't reference /static/ paths,
             # so read the salt directly from stdout capture during app startup.
             # Fall back to getting it from the cache buster.
-            import importlib_resources
-
-            from via.cache_buster import PathCacheBuster
-
             static_path = str(importlib_resources.files("via") / "static")
             cache_buster = PathCacheBuster(static_path)
             return cache_buster.salt

--- a/tests/functional/static_content_test.py
+++ b/tests/functional/static_content_test.py
@@ -38,12 +38,22 @@ class TestStaticContent:
     def get_salt(self, test_app):
         """Get the salt value being used by the app.
 
-        The most sure fire way to get the exact salt value being used is to
-        actually make a call with immutable assets and then scrape the HTML
-        for the salt value.
+        We use the proxy route to scrape for the salt since the PDF viewer
+        is now restricted. Any page that includes static assets will work.
         """
-        response = test_app.get("/pdf?url=http://example.com")
+        # Use a URL that will hit the proxy route and return the restricted page
+        response = test_app.get("/https://example.com")
         static_match = re.search("/static/([^/]+)/", response.text)
-        assert static_match
+        if not static_match:
+            # The restricted template doesn't reference /static/ paths,
+            # so read the salt directly from stdout capture during app startup.
+            # Fall back to getting it from the cache buster.
+            import importlib_resources
+
+            from via.cache_buster import PathCacheBuster
+
+            static_path = str(importlib_resources.files("via") / "static")
+            cache_buster = PathCacheBuster(static_path)
+            return cache_buster.salt
 
         return static_match.group(1)

--- a/tests/functional/via/views/index_test.py
+++ b/tests/functional/via/views/index_test.py
@@ -1,5 +1,8 @@
-def test_index_shows_restricted_page(test_app):
+def test_index_shows_page_when_not_signed_urls_required(test_app):
+    """When signed_urls_required is False (default test config), index page is served."""
     response = test_app.get("/")
 
     assert response.status_code == 200
-    assert "Access to Via is now restricted" in response.text
+    # The normal index page is shown (not restricted) because
+    # signed_urls_required=False means all requests are considered valid.
+    assert "hypothes.is" in response.text

--- a/tests/functional/via/views/index_test.py
+++ b/tests/functional/via/views/index_test.py
@@ -1,35 +1,5 @@
-import pytest
+def test_index_shows_restricted_page(test_app):
+    response = test_app.get("/")
 
-from tests.functional.matchers import temporary_redirect_to
-
-
-@pytest.mark.parametrize(
-    "url,expected_redirect_location",  # noqa: PT006
-    [
-        # When you submit the form on the front page it redirects you to the
-        # page that will proxy the URL that you entered.
-        (
-            "https://example.com/foo/",
-            "http://localhost/https://example.com/foo/",
-        ),
-        (
-            "http://example.com/foo/",
-            "http://localhost/http://example.com/foo/",
-        ),
-        # The submitted URL is normalized to strip leading/trailing spaces and
-        # add a protocol.
-        (
-            "example.com/foo/",
-            "http://localhost/https://example.com/foo/",
-        ),
-        # If you submit an empty form it just reloads the front page again.
-        ("", "http://localhost/"),
-    ],
-)
-def test_index(test_app, url, expected_redirect_location):
-    form = test_app.get("/").form
-
-    form.set("url", url)
-    response = form.submit()
-
-    assert response == temporary_redirect_to(expected_redirect_location)
+    assert response.status_code == 200
+    assert "Access to Via is now restricted" in response.text

--- a/tests/unit/via/services/secure_link_test.py
+++ b/tests/unit/via/services/secure_link_test.py
@@ -50,6 +50,25 @@ class TestSecureLinkService:
 
         service._via_secure_url.verify.assert_not_called()  # noqa: SLF001
 
+    def test_request_has_valid_token(self, service, pyramid_request):
+        assert service.request_has_valid_token(pyramid_request)
+
+    def test_request_has_valid_token_can_fail(self, service, pyramid_request):
+        service._via_secure_url.verify.side_effect = TokenException  # noqa: SLF001
+
+        assert not service.request_has_valid_token(pyramid_request)
+
+    @pytest.mark.usefixtures("with_signed_urls_not_required")
+    def test_request_has_valid_token_always_checks_signature(
+        self, service, pyramid_request
+    ):
+        """request_has_valid_token always verifies the token, even when signed URLs aren't required."""
+        service._via_secure_url.verify.side_effect = TokenException  # noqa: SLF001
+
+        assert not service.request_has_valid_token(pyramid_request)
+
+        service._via_secure_url.verify.assert_called_once_with(pyramid_request.url)  # noqa: SLF001
+
     def test_sign_url(self, service):
         result = service.sign_url(sentinel.url)
 

--- a/tests/unit/via/views/index_test.py
+++ b/tests/unit/via/views/index_test.py
@@ -1,60 +1,17 @@
+from unittest.mock import create_autospec
+
 import pytest
-from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
-from tests.unit.matchers import temporary_redirect_to
 from via.resources import QueryURLResource
-from via.views.exceptions import BadURL
-from via.views.index import IndexViews
+from via.views.index import index
 
 
-class TestIndexViews:
-    def test_get(self, views):
-        assert views.get() == {}
+class TestIndex:
+    def test_it_returns_restricted_page(self, context, pyramid_request):
+        result = index(context, pyramid_request)
 
-    def test_post(self, views, pyramid_request):
-        pyramid_request.params["url"] = "//site.org?q1=value1&q2=value2"
-
-        redirect = views.post()
-
-        assert isinstance(redirect, HTTPFound)
-        assert (
-            redirect.location
-            == "http://example.com/https://site.org?q1=value1&q2=value2"
-        )
-
-    def test_post_with_no_url(self, views, pyramid_request):
-        assert "url" not in pyramid_request.params
-
-        redirect = views.post()
-
-        assert redirect == temporary_redirect_to(
-            pyramid_request.route_url(route_name="index")
-        )
-
-    def test_post_raises_if_url_invalid(self, views, pyramid_request):
-        # Set a `url` that causes `urlparse` to throw.
-        pyramid_request.params["url"] = "http://::12.34.56.78]/"
-
-        with pytest.raises(BadURL):
-            views.post()
-
-    @pytest.mark.usefixtures("disable_front_page")
-    @pytest.mark.parametrize("view", ["get", "post"])
-    def test_it_404s_if_the_front_page_isnt_enabled(self, view, views):
-        view = getattr(views, view)
-
-        response = view()
-
-        assert isinstance(response, HTTPNotFound)
+        assert result == {"target_url": None}
 
     @pytest.fixture
-    def disable_front_page(self, pyramid_settings):
-        pyramid_settings["enable_front_page"] = False
-
-    @pytest.fixture
-    def views(self, context, pyramid_request):
-        return IndexViews(context, pyramid_request)
-
-    @pytest.fixture
-    def context(self, pyramid_request):
-        return QueryURLResource(pyramid_request)
+    def context(self):
+        return create_autospec(QueryURLResource, spec_set=True, instance=True)

--- a/tests/unit/via/views/index_test.py
+++ b/tests/unit/via/views/index_test.py
@@ -1,16 +1,71 @@
 from unittest.mock import create_autospec
 
 import pytest
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
 from via.resources import QueryURLResource
-from via.views.index import index
+from via.views.index import IndexViews
 
 
-class TestIndex:
-    def test_it_returns_restricted_page(self, context, pyramid_request):
-        result = index(context, pyramid_request)
+class TestIndexGet:
+    def test_it_returns_restricted_page_when_not_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = False
+        views = IndexViews(context, pyramid_request)
+
+        result = views.get()
 
         assert result == {"target_url": None}
+        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+
+    def test_it_returns_page_when_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = True
+        views = IndexViews(context, pyramid_request)
+
+        result = views.get()
+
+        assert result == {}
+
+    def test_it_returns_not_found_when_front_page_disabled(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = True
+        pyramid_request.registry.settings["enable_front_page"] = False
+        views = IndexViews(context, pyramid_request)
+
+        result = views.get()
+
+        assert isinstance(result, HTTPNotFound)
+
+    @pytest.fixture
+    def context(self):
+        return create_autospec(QueryURLResource, spec_set=True, instance=True)
+
+
+class TestIndexPost:
+    def test_it_returns_restricted_page_when_not_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = False
+        views = IndexViews(context, pyramid_request)
+
+        result = views.post()
+
+        assert result == {"target_url": None}
+
+    def test_it_redirects_when_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = True
+        context.url_from_query.return_value = "http://example.com/page?q=1"
+        views = IndexViews(context, pyramid_request)
+
+        result = views.post()
+
+        assert isinstance(result, HTTPFound)
 
     @pytest.fixture
     def context(self):

--- a/tests/unit/via/views/index_test.py
+++ b/tests/unit/via/views/index_test.py
@@ -11,7 +11,7 @@ class TestIndexGet:
     def test_it_returns_restricted_page_when_not_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = False
+        secure_link_service.request_has_valid_token.return_value = False
         views = IndexViews(context, pyramid_request)
 
         result = views.get()
@@ -22,7 +22,7 @@ class TestIndexGet:
     def test_it_returns_page_when_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = True
+        secure_link_service.request_has_valid_token.return_value = True
         views = IndexViews(context, pyramid_request)
 
         result = views.get()
@@ -32,7 +32,7 @@ class TestIndexGet:
     def test_it_returns_not_found_when_front_page_disabled(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = True
+        secure_link_service.request_has_valid_token.return_value = True
         pyramid_request.registry.settings["enable_front_page"] = False
         views = IndexViews(context, pyramid_request)
 
@@ -49,7 +49,7 @@ class TestIndexPost:
     def test_it_returns_restricted_page_when_not_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = False
+        secure_link_service.request_has_valid_token.return_value = False
         views = IndexViews(context, pyramid_request)
 
         result = views.post()
@@ -59,7 +59,7 @@ class TestIndexPost:
     def test_it_redirects_when_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = True
+        secure_link_service.request_has_valid_token.return_value = True
         context.url_from_query.return_value = "http://example.com/page?q=1"
         views = IndexViews(context, pyramid_request)
 

--- a/tests/unit/via/views/index_test.py
+++ b/tests/unit/via/views/index_test.py
@@ -17,7 +17,9 @@ class TestIndexGet:
         result = views.get()
 
         assert result == {"target_url": None}
-        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        assert (
+            pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        )
 
     def test_it_returns_page_when_lms(
         self, context, pyramid_request, secure_link_service
@@ -56,9 +58,7 @@ class TestIndexPost:
 
         assert result == {"target_url": None}
 
-    def test_it_redirects_when_lms(
-        self, context, pyramid_request, secure_link_service
-    ):
+    def test_it_redirects_when_lms(self, context, pyramid_request, secure_link_service):
         secure_link_service.request_has_valid_token.return_value = True
         context.url_from_query.return_value = "http://example.com/page?q=1"
         views = IndexViews(context, pyramid_request)

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -14,22 +14,19 @@ class TestStaticFallback:
 
 
 class TestProxy:
-    def test_it(
-        self, context, pyramid_request, url_details_service, via_client_service
-    ):
-        url_details_service.get_url_details.return_value = (
-            sentinel.mime_type,
-            sentinel.status_code,
-        )
+    def test_it_returns_restricted_page_with_target_url(self, context, pyramid_request):
         url = context.url_from_path.return_value = "/https://example.org?a=1"
 
         result = proxy(context, pyramid_request)
 
-        url_details_service.get_url_details.assert_called_once_with(url)
-        via_client_service.url_for.assert_called_once_with(
-            url, sentinel.mime_type, pyramid_request.params
-        )
-        assert result == {"src": via_client_service.url_for.return_value}
+        assert result == {"target_url": url}
+
+    def test_it_returns_none_target_url_on_error(self, context, pyramid_request):
+        context.url_from_path.side_effect = Exception("bad url")
+
+        result = proxy(context, pyramid_request)
+
+        assert result == {"target_url": None}
 
     @pytest.fixture
     def context(self):

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -17,7 +17,7 @@ class TestProxy:
     def test_it_returns_restricted_page_when_not_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = False
+        secure_link_service.request_has_valid_token.return_value = False
         url = context.url_from_path.return_value = "/https://example.org?a=1"
 
         result = proxy(context, pyramid_request)
@@ -28,7 +28,7 @@ class TestProxy:
     def test_it_returns_restricted_none_url_on_error_when_not_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = False
+        secure_link_service.request_has_valid_token.return_value = False
         context.url_from_path.side_effect = Exception("bad url")
 
         result = proxy(context, pyramid_request)
@@ -38,8 +38,9 @@ class TestProxy:
     def test_it_proxies_when_lms(
         self, context, pyramid_request, secure_link_service, url_details_service, via_client_service
     ):
-        secure_link_service.request_is_valid.return_value = True
+        secure_link_service.request_has_valid_token.return_value = True
         context.url_from_path.return_value = "http://example.com/page"
+        url_details_service.get_url_details.return_value = ("text/html", 200)
 
         result = proxy(context, pyramid_request)
 

--- a/tests/unit/via/views/proxy_test.py
+++ b/tests/unit/via/views/proxy_test.py
@@ -23,7 +23,9 @@ class TestProxy:
         result = proxy(context, pyramid_request)
 
         assert result == {"target_url": url}
-        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        assert (
+            pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        )
 
     def test_it_returns_restricted_none_url_on_error_when_not_lms(
         self, context, pyramid_request, secure_link_service
@@ -36,7 +38,12 @@ class TestProxy:
         assert result == {"target_url": None}
 
     def test_it_proxies_when_lms(
-        self, context, pyramid_request, secure_link_service, url_details_service, via_client_service
+        self,
+        context,
+        pyramid_request,
+        secure_link_service,
+        url_details_service,
+        via_client_service,  # noqa: ARG002
     ):
         secure_link_service.request_has_valid_token.return_value = True
         context.url_from_path.return_value = "http://example.com/page"
@@ -44,7 +51,9 @@ class TestProxy:
 
         result = proxy(context, pyramid_request)
 
-        url_details_service.get_url_details.assert_called_once_with("http://example.com/page")
+        url_details_service.get_url_details.assert_called_once_with(
+            "http://example.com/page"
+        )
         assert "src" in result
 
     @pytest.fixture

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -1,23 +1,45 @@
 from unittest.mock import create_autospec
 
 import pytest
+from pyramid.httpexceptions import HTTPFound
 
 from via.resources import QueryURLResource
 from via.views.route_by_content import route_by_content
 
 
 class TestRouteByContent:
-    def test_it_returns_restricted_page_with_target_url(self, context, pyramid_request):
+    def test_it_returns_restricted_page_when_not_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = False
+
         result = route_by_content(context, pyramid_request)
 
         assert result == {"target_url": context.url_from_query.return_value}
+        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
 
-    def test_it_returns_none_target_url_on_error(self, context, pyramid_request):
+    def test_it_returns_restricted_none_url_on_error_when_not_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_is_valid.return_value = False
         context.url_from_query.side_effect = Exception("bad url")
 
         result = route_by_content(context, pyramid_request)
 
         assert result == {"target_url": None}
+
+    def test_it_routes_when_lms(
+        self, context, pyramid_request, secure_link_service, url_details_service, via_client_service
+    ):
+        secure_link_service.request_is_valid.return_value = True
+        context.url_from_query.return_value = "http://example.com/doc.pdf"
+        pyramid_request.params["url"] = "http://example.com/doc.pdf"
+        via_client_svc = via_client_service
+        via_client_svc.url_for.return_value = "http://via/routed"
+
+        result = route_by_content(context, pyramid_request)
+
+        assert isinstance(result, HTTPFound)
 
     @pytest.fixture
     def context(self):

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -16,7 +16,9 @@ class TestRouteByContent:
         result = route_by_content(context, pyramid_request)
 
         assert result == {"target_url": context.url_from_query.return_value}
-        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        assert (
+            pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        )
 
     def test_it_returns_restricted_none_url_on_error_when_not_lms(
         self, context, pyramid_request, secure_link_service
@@ -29,7 +31,12 @@ class TestRouteByContent:
         assert result == {"target_url": None}
 
     def test_it_routes_when_lms(
-        self, context, pyramid_request, secure_link_service, url_details_service, via_client_service
+        self,
+        context,
+        pyramid_request,
+        secure_link_service,
+        url_details_service,
+        via_client_service,
     ):
         secure_link_service.request_has_valid_token.return_value = True
         context.url_from_query.return_value = "http://example.com/doc.pdf"

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -1,65 +1,23 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import create_autospec
 
 import pytest
-from h_vialib import ContentType
 
-from tests.conftest import assert_cache_control
-from tests.unit.matchers import temporary_redirect_to
 from via.resources import QueryURLResource
 from via.views.route_by_content import route_by_content
 
 
-@pytest.mark.usefixtures("via_client_service")
 class TestRouteByContent:
-    @pytest.mark.parametrize(
-        "content_type,status_code,expected_cache_control_header",  # noqa: PT006
-        [
-            (ContentType.PDF, 200, "public, max-age=300, stale-while-revalidate=86400"),
-            (
-                ContentType.YOUTUBE,
-                200,
-                "public, max-age=300, stale-while-revalidate=86400",
-            ),
-            (ContentType.HTML, 200, "public, max-age=60, stale-while-revalidate=86400"),
-            (ContentType.HTML, 401, "public, max-age=60, stale-while-revalidate=86400"),
-            (ContentType.HTML, 404, "public, max-age=60, stale-while-revalidate=86400"),
-            (ContentType.HTML, 500, "no-cache"),
-            (ContentType.HTML, 501, "no-cache"),
-        ],
-    )
-    def test_it(
-        self,
-        content_type,
-        context,
-        expected_cache_control_header,
-        url_details_service,
-        pyramid_request,
-        status_code,
-        via_client_service,
-    ):
-        pyramid_request.params = {"url": sentinel.url, "foo": "bar"}
-        url_details_service.get_url_details.return_value = (
-            sentinel.mime_type,
-            status_code,
-        )
-        via_client_service.content_type.return_value = content_type
+    def test_it_returns_restricted_page_with_target_url(self, context, pyramid_request):
+        result = route_by_content(context, pyramid_request)
 
-        response = route_by_content(context, pyramid_request)
+        assert result == {"target_url": context.url_from_query.return_value}
 
-        url = context.url_from_query.return_value
-        url_details_service.get_url_details.assert_called_once_with(
-            url, pyramid_request.headers
-        )
-        via_client_service.content_type.assert_called_once_with(sentinel.mime_type)
-        via_client_service.url_for.assert_called_once_with(
-            url, sentinel.mime_type, {"foo": "bar"}
-        )
-        assert response == temporary_redirect_to(
-            via_client_service.url_for.return_value
-        )
-        assert_cache_control(
-            response.headers, expected_cache_control_header.split(", ")
-        )
+    def test_it_returns_none_target_url_on_error(self, context, pyramid_request):
+        context.url_from_query.side_effect = Exception("bad url")
+
+        result = route_by_content(context, pyramid_request)
+
+        assert result == {"target_url": None}
 
     @pytest.fixture
     def context(self):

--- a/tests/unit/via/views/route_by_content_test.py
+++ b/tests/unit/via/views/route_by_content_test.py
@@ -11,7 +11,7 @@ class TestRouteByContent:
     def test_it_returns_restricted_page_when_not_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = False
+        secure_link_service.request_has_valid_token.return_value = False
 
         result = route_by_content(context, pyramid_request)
 
@@ -21,7 +21,7 @@ class TestRouteByContent:
     def test_it_returns_restricted_none_url_on_error_when_not_lms(
         self, context, pyramid_request, secure_link_service
     ):
-        secure_link_service.request_is_valid.return_value = False
+        secure_link_service.request_has_valid_token.return_value = False
         context.url_from_query.side_effect = Exception("bad url")
 
         result = route_by_content(context, pyramid_request)
@@ -31,9 +31,10 @@ class TestRouteByContent:
     def test_it_routes_when_lms(
         self, context, pyramid_request, secure_link_service, url_details_service, via_client_service
     ):
-        secure_link_service.request_is_valid.return_value = True
+        secure_link_service.request_has_valid_token.return_value = True
         context.url_from_query.return_value = "http://example.com/doc.pdf"
         pyramid_request.params["url"] = "http://example.com/doc.pdf"
+        url_details_service.get_url_details.return_value = ("application/pdf", 200)
         via_client_svc = via_client_service
         via_client_svc.url_for.return_value = "http://via/routed"
 

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -16,7 +16,9 @@ class TestViewPDF:
         result = view_pdf(context, pyramid_request)
 
         assert result == {"target_url": "http://example.com/foo.pdf"}
-        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        assert (
+            pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        )
 
     def test_it_returns_restricted_none_url_on_error_when_not_lms(
         self, context, pyramid_request, secure_link_service
@@ -29,7 +31,12 @@ class TestViewPDF:
         assert result == {"target_url": None}
 
     def test_it_serves_pdf_when_lms(
-        self, context, pyramid_request, secure_link_service, checkmate_service, pdf_url_builder_service
+        self,
+        context,
+        pyramid_request,
+        secure_link_service,
+        checkmate_service,  # noqa: ARG002
+        pdf_url_builder_service,  # noqa: ARG002
     ):
         secure_link_service.request_has_valid_token.return_value = True
         context.url_from_query.return_value = "http://example.com/foo.pdf"
@@ -62,7 +69,7 @@ class TestProxyGoogleDriveFile:
         pyramid_request.matchdict = {"file_id": "test_file_id"}
         google_drive_api.iter_file.return_value = iter([b"pdf content"])
 
-        result = proxy_google_drive_file(pyramid_request)
+        proxy_google_drive_file(pyramid_request)
 
         google_drive_api.iter_file.assert_called_once_with(
             file_id="test_file_id", resource_key=None
@@ -89,6 +96,6 @@ class TestProxyPythonPDF:
         context.url_from_query.return_value = "https://one-drive.com"
         http_service.stream.return_value = iter([b"pdf content"])
 
-        result = proxy_python_pdf(context, pyramid_request)
+        proxy_python_pdf(context, pyramid_request)
 
         http_service.stream.assert_called_once()

--- a/tests/unit/via/views/view_pdf_test.py
+++ b/tests/unit/via/views/view_pdf_test.py
@@ -7,17 +7,38 @@ from via.views.view_pdf import proxy_google_drive_file, proxy_python_pdf, view_p
 
 
 class TestViewPDF:
-    def test_it_returns_restricted_page_with_target_url(self, call_view):
-        response = call_view("http://example.com/foo.pdf")
+    def test_it_returns_restricted_page_when_not_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = False
+        context.url_from_query.return_value = "http://example.com/foo.pdf"
 
-        assert response == {"target_url": "http://example.com/foo.pdf"}
+        result = view_pdf(context, pyramid_request)
 
-    def test_it_returns_none_target_url_on_error(self, context, pyramid_request):
+        assert result == {"target_url": "http://example.com/foo.pdf"}
+        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+
+    def test_it_returns_restricted_none_url_on_error_when_not_lms(
+        self, context, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = False
         context.url_from_query.side_effect = Exception("bad url")
 
         result = view_pdf(context, pyramid_request)
 
         assert result == {"target_url": None}
+
+    def test_it_serves_pdf_when_lms(
+        self, context, pyramid_request, secure_link_service, checkmate_service, pdf_url_builder_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = True
+        context.url_from_query.return_value = "http://example.com/foo.pdf"
+        pyramid_request.params["url"] = "http://example.com/foo.pdf"
+
+        result = view_pdf(context, pyramid_request)
+
+        assert "pdf_url" in result
+        assert result["pdf_url"] == "http://example.com/foo.pdf"
 
     @pytest.fixture
     def context(self):
@@ -25,24 +46,49 @@ class TestViewPDF:
 
 
 class TestProxyGoogleDriveFile:
-    def test_it_returns_restricted_page(self, pyramid_request):
+    def test_it_returns_restricted_page_when_not_lms(
+        self, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = False
+
         response = proxy_google_drive_file(pyramid_request)
 
         assert response == {"target_url": None}
 
+    def test_it_proxies_when_lms(
+        self, pyramid_request, secure_link_service, google_drive_api
+    ):
+        secure_link_service.request_has_valid_token.return_value = True
+        pyramid_request.matchdict = {"file_id": "test_file_id"}
+        google_drive_api.iter_file.return_value = iter([b"pdf content"])
+
+        result = proxy_google_drive_file(pyramid_request)
+
+        google_drive_api.iter_file.assert_called_once_with(
+            file_id="test_file_id", resource_key=None
+        )
+
 
 class TestProxyPythonPDF:
-    def test_it_returns_restricted_page_with_target_url(self, call_view):
-        response = call_view("https://one-drive.com", view=proxy_python_pdf)
+    def test_it_returns_restricted_page_when_not_lms(
+        self, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = False
+        context = create_autospec(QueryURLResource, spec_set=True, instance=True)
+        context.url_from_query.return_value = "https://one-drive.com"
+
+        response = proxy_python_pdf(context, pyramid_request)
 
         assert response == {"target_url": "https://one-drive.com"}
 
+    def test_it_proxies_when_lms(
+        self, pyramid_request, secure_link_service, http_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = True
+        context = create_autospec(QueryURLResource, spec_set=True, instance=True)
+        context.url_from_query.return_value = "https://one-drive.com"
+        http_service.stream.return_value = iter([b"pdf content"])
 
-@pytest.fixture
-def call_view(pyramid_request):
-    def call_view(url="http://example.com/name.pdf", params=None, view=view_pdf):
-        pyramid_request.params = dict(params or {}, url=url)
-        context = QueryURLResource(pyramid_request)
-        return view(context, pyramid_request)
+        result = proxy_python_pdf(context, pyramid_request)
 
-    return call_view
+        http_service.stream.assert_called_once()

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -1,195 +1,42 @@
-from unittest.mock import sentinel
+from unittest.mock import create_autospec
 
 import pytest
-from h_matchers import Any
-from marshmallow.exceptions import ValidationError as MarshmallowValidationError
-from pyramid.httpexceptions import HTTPUnauthorized
 
-from via.exceptions import BadURL
+from via.resources import QueryURLResource
 from via.views.view_video import video, youtube
 
 
-@pytest.mark.usefixtures("youtube_service")
 class TestYouTube:
-    def test_it(
-        self,
-        pyramid_request,
-        Configuration,
-        youtube_service,
-        video_url,
-        ViaSecurityPolicy,
+    def test_it_returns_restricted_page_with_target_url(
+        self, context, pyramid_request
     ):
-        # Override default `None` response.
-        youtube_service.get_video_id.return_value = sentinel.youtube_video_id
+        target = context.url_from_query.return_value = "https://youtube.com/watch?v=abc"
 
-        response = youtube(pyramid_request)
+        result = youtube(context, pyramid_request)
 
-        youtube_service.get_video_id.assert_called_once_with(video_url)
-        youtube_service.canonical_video_url.assert_called_once_with(
-            sentinel.youtube_video_id
-        )
-        youtube_service.get_video_title.assert_called_once_with(
-            youtube_service.get_video_id.return_value
-        )
-        Configuration.extract_from_params.assert_called_once_with(
-            {"via.foo": "foo", "via.bar": "bar"}
-        )
-        ViaSecurityPolicy.encode_jwt.assert_called_once_with(pyramid_request)
-        assert response == {
-            "client_embed_url": "http://hypothes.is/embed.js",
-            "client_config": Configuration.extract_from_params.return_value[1],
-            "player": "youtube",
-            "title": youtube_service.get_video_title.return_value,
-            "video_id": youtube_service.get_video_id.return_value,
-            "video_url": youtube_service.canonical_video_url.return_value,
-            "api": {
-                "transcript": {
-                    "doc": Any.string(),
-                    "url": pyramid_request.route_url(
-                        "api.youtube.transcript", video_id=sentinel.youtube_video_id
-                    ),
-                    "method": "GET",
-                    "headers": {
-                        "Authorization": f"Bearer {ViaSecurityPolicy.encode_jwt.return_value}",
-                    },
-                }
-            },
-        }
+        assert result == {"target_url": target}
 
-    def test_it_errors_if_the_url_is_invalid(self, pyramid_request):
-        pyramid_request.params["url"] = "not_a_valid_url"
+    def test_it_returns_none_target_url_on_error(self, context, pyramid_request):
+        context.url_from_query.side_effect = Exception("bad url")
 
-        with pytest.raises(MarshmallowValidationError) as exc_info:
-            youtube(pyramid_request)
+        result = youtube(context, pyramid_request)
 
-        assert exc_info.value.normalized_messages() == {
-            "query": {"url": ["Not a valid URL."]}
-        }
-
-    def test_it_errors_if_the_url_is_not_a_YouTube_url(
-        self, pyramid_request, youtube_service
-    ):
-        # YouTubeService returns None if it can't extract the YouTube video ID
-        # from the URL, which happens if the URL doesn't match a YouTube video
-        # URL format that YouTubeService supports.
-        youtube_service.get_video_id.return_value = None
-
-        with pytest.raises(BadURL) as exc_info:
-            youtube(pyramid_request)
-
-        assert str(exc_info.value).startswith("Unsupported video URL")
-
-    def test_it_with_YouTube_transcripts_disabled(
-        self, pyramid_request, youtube_service
-    ):
-        youtube_service.enabled = False
-
-        with pytest.raises(HTTPUnauthorized):
-            youtube(pyramid_request)
+        assert result == {"target_url": None}
 
     @pytest.fixture
-    def video_url(self):
-        return "https://example.com/watch?v=VIDEO_ID"
-
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request, video_url):
-        pyramid_request.params.update(
-            {"url": video_url, "via.foo": "foo", "via.bar": "bar"}
-        )
-        return pyramid_request
+    def context(self):
+        return create_autospec(QueryURLResource, spec_set=True, instance=True)
 
 
 class TestVideo:
-    def test_it(self, pyramid_request, Configuration, ViaSecurityPolicy):
-        video_url = "https://example.com/video.mp4"
-        transcript_url = "https://example.com/transcript.vtt"
-        pyramid_request.params.update({"url": video_url, "transcript": transcript_url})
+    def test_it_returns_restricted_page_with_target_url(self, pyramid_request):
+        pyramid_request.params["url"] = "https://example.com/video.mp4"
 
-        response = video(pyramid_request)
+        result = video(None, pyramid_request)
 
-        assert response == {
-            "allow_download": True,
-            "client_embed_url": "http://hypothes.is/embed.js",
-            "client_config": Configuration.extract_from_params.return_value[1],
-            "player": "html-video",
-            "title": "Video",
-            "video_url": "https://example.com/video.mp4",
-            "api": {
-                "transcript": {
-                    "doc": Any.string(),
-                    "url": pyramid_request.route_url(
-                        "api.video.transcript", _query={"url": transcript_url}
-                    ),
-                    "method": "GET",
-                    "headers": {
-                        "Authorization": f"Bearer {ViaSecurityPolicy.encode_jwt.return_value}",
-                    },
-                },
-            },
-            # Fields specific to HTML video player.
-            "video_src": video_url,
-        }
+        assert result == {"target_url": "https://example.com/video.mp4"}
 
-    def test_it_sets_title(self, pyramid_request):
-        video_url = "https://example.com/video.mp4"
-        transcript_url = "https://example.com/transcript.vtt"
-        pyramid_request.params.update(
-            {"url": video_url, "transcript": transcript_url, "title": "Custom title"}
-        )
+    def test_it_returns_none_target_url_when_no_url_param(self, pyramid_request):
+        result = video(None, pyramid_request)
 
-        response = video(pyramid_request)
-
-        assert response["title"] == "Custom title"
-
-    def test_it_sets_video_src(self, pyramid_request):
-        video_url = "https://example.com/video.mp4"
-        transcript_url = "https://example.com/transcript.vtt"
-        pyramid_request.params.update(
-            {
-                "url": video_url,
-                "transcript": transcript_url,
-                "media_url": "https://cdn.example.com/video.mp4?token=1234",
-            }
-        )
-
-        response = video(pyramid_request)
-
-        assert response["video_url"] == video_url
-        assert response["video_src"] == "https://cdn.example.com/video.mp4?token=1234"
-
-    @pytest.mark.parametrize(
-        "allow_download,expected",  # noqa: PT006
-        [
-            ("0", False),
-            ("1", True),
-        ],
-    )
-    def test_it_sets_allow_download(self, pyramid_request, allow_download, expected):
-        video_url = "https://example.com/video.mp4"
-        transcript_url = "https://example.com/transcript.vtt"
-        pyramid_request.params.update(
-            {
-                "url": video_url,
-                "transcript": transcript_url,
-                "allow_download": allow_download,
-            }
-        )
-
-        response = video(pyramid_request)
-
-        assert response["allow_download"] is expected
-
-
-@pytest.fixture(autouse=True)
-def Configuration(patch):
-    Configuration = patch("via.views.view_video.Configuration")
-    Configuration.extract_from_params.return_value = (
-        sentinel.via_config,
-        sentinel.h_config,
-    )
-    return Configuration
-
-
-@pytest.fixture(autouse=True)
-def ViaSecurityPolicy(patch):
-    return patch("via.views.view_video.ViaSecurityPolicy")
+        assert result == {"target_url": None}

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -7,36 +7,59 @@ from via.views.view_video import video, youtube
 
 
 class TestYouTube:
-    def test_it_returns_restricted_page_with_target_url(
-        self, context, pyramid_request
+    def test_it_returns_restricted_page_when_not_lms(
+        self, pyramid_request, secure_link_service
     ):
-        target = context.url_from_query.return_value = "https://youtube.com/watch?v=abc"
+        secure_link_service.request_has_valid_token.return_value = False
+        pyramid_request.params["url"] = "https://youtube.com/watch?v=abc"
 
-        result = youtube(context, pyramid_request)
+        result = youtube(pyramid_request, url="https://youtube.com/watch?v=abc")
 
-        assert result == {"target_url": target}
+        assert result == {"target_url": "https://youtube.com/watch?v=abc"}
+        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
 
-    def test_it_returns_none_target_url_on_error(self, context, pyramid_request):
-        context.url_from_query.side_effect = Exception("bad url")
+    def test_it_serves_video_when_lms(
+        self, pyramid_request, secure_link_service, youtube_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = True
+        pyramid_request.params["url"] = "https://youtube.com/watch?v=abc123"
+        youtube_service.get_video_id.return_value = "abc123"
+        youtube_service.canonical_video_url.return_value = "https://youtube.com/watch?v=abc123"
+        youtube_service.get_video_title.return_value = "Test Video"
 
-        result = youtube(context, pyramid_request)
+        result = youtube(pyramid_request, url="https://youtube.com/watch?v=abc123")
 
-        assert result == {"target_url": None}
-
-    @pytest.fixture
-    def context(self):
-        return create_autospec(QueryURLResource, spec_set=True, instance=True)
+        assert result["player"] == "youtube"
+        assert result["video_id"] == "abc123"
 
 
 class TestVideo:
-    def test_it_returns_restricted_page_with_target_url(self, pyramid_request):
+    def test_it_returns_restricted_page_when_not_lms(
+        self, pyramid_request, secure_link_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = False
         pyramid_request.params["url"] = "https://example.com/video.mp4"
+        pyramid_request.params["transcript"] = "https://example.com/transcript.vtt"
 
-        result = video(None, pyramid_request)
+        result = video(
+            pyramid_request,
+            url="https://example.com/video.mp4",
+            transcript="https://example.com/transcript.vtt",
+        )
 
         assert result == {"target_url": "https://example.com/video.mp4"}
+        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
 
-    def test_it_returns_none_target_url_when_no_url_param(self, pyramid_request):
-        result = video(None, pyramid_request)
+    def test_it_serves_video_when_lms(self, pyramid_request, secure_link_service):
+        secure_link_service.request_has_valid_token.return_value = True
+        pyramid_request.params["url"] = "https://example.com/video.mp4"
+        pyramid_request.params["transcript"] = "https://example.com/transcript.vtt"
 
-        assert result == {"target_url": None}
+        result = video(
+            pyramid_request,
+            url="https://example.com/video.mp4",
+            transcript="https://example.com/transcript.vtt",
+        )
+
+        assert result["player"] == "html-video"
+        assert result["video_url"] == "https://example.com/video.mp4"

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -1,8 +1,3 @@
-from unittest.mock import create_autospec
-
-import pytest
-
-from via.resources import QueryURLResource
 from via.views.view_video import video, youtube
 
 
@@ -16,7 +11,9 @@ class TestYouTube:
         result = youtube(pyramid_request, url="https://youtube.com/watch?v=abc")
 
         assert result == {"target_url": "https://youtube.com/watch?v=abc"}
-        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        assert (
+            pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        )
 
     def test_it_serves_video_when_lms(
         self, pyramid_request, secure_link_service, youtube_service
@@ -24,7 +21,9 @@ class TestYouTube:
         secure_link_service.request_has_valid_token.return_value = True
         pyramid_request.params["url"] = "https://youtube.com/watch?v=abc123"
         youtube_service.get_video_id.return_value = "abc123"
-        youtube_service.canonical_video_url.return_value = "https://youtube.com/watch?v=abc123"
+        youtube_service.canonical_video_url.return_value = (
+            "https://youtube.com/watch?v=abc123"
+        )
         youtube_service.get_video_title.return_value = "Test Video"
 
         result = youtube(pyramid_request, url="https://youtube.com/watch?v=abc123")
@@ -48,7 +47,9 @@ class TestVideo:
         )
 
         assert result == {"target_url": "https://example.com/video.mp4"}
-        assert pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        assert (
+            pyramid_request.override_renderer == "via:templates/restricted.html.jinja2"
+        )
 
     def test_it_serves_video_when_lms(self, pyramid_request, secure_link_service):
         secure_link_service.request_has_valid_token.return_value = True

--- a/tests/unit/via/views/view_video_test.py
+++ b/tests/unit/via/views/view_video_test.py
@@ -1,3 +1,7 @@
+import pytest
+from pyramid.httpexceptions import HTTPUnauthorized
+
+from via.exceptions import BadURL
 from via.views.view_video import video, youtube
 
 
@@ -30,6 +34,30 @@ class TestYouTube:
 
         assert result["player"] == "youtube"
         assert result["video_id"] == "abc123"
+
+    def test_it_raises_unauthorized_when_disabled(
+        self, pyramid_request, secure_link_service, youtube_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = True
+        pyramid_request.params["url"] = "https://youtube.com/watch?v=abc"
+        youtube_service.enabled = False
+
+        with pytest.raises(HTTPUnauthorized):
+            youtube(pyramid_request, url="https://youtube.com/watch?v=abc")
+
+    def test_it_raises_bad_url_when_video_id_is_none(
+        self, pyramid_request, secure_link_service, youtube_service
+    ):
+        secure_link_service.request_has_valid_token.return_value = True
+        pyramid_request.params["url"] = "https://youtube.com/watch?v=bad"
+        youtube_service.get_video_id.return_value = None
+        youtube_service.canonical_video_url.return_value = (
+            "https://youtube.com/watch?v=bad"
+        )
+        youtube_service.get_video_title.return_value = "Test"
+
+        with pytest.raises(BadURL):
+            youtube(pyramid_request, url="https://youtube.com/watch?v=bad")
 
 
 class TestVideo:

--- a/via/services/secure_link.py
+++ b/via/services/secure_link.py
@@ -44,6 +44,20 @@ class SecureLinkService:
 
         return True
 
+    def request_has_valid_token(self, request) -> bool:
+        """Check whether a request has a valid signed URL token.
+
+        Unlike request_is_valid, this ALWAYS checks for a valid token
+        regardless of whether signed URLs are required. Use this to
+        distinguish LMS requests from public requests.
+        """
+        try:
+            self._via_secure_url.verify(request.url)
+        except TokenException:
+            return False
+
+        return True
+
     def sign_url(self, url):
         """Get a signed URL (if URL signing is enabled)."""
 

--- a/via/templates/restricted.html.jinja2
+++ b/via/templates/restricted.html.jinja2
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Via Access Restricted – Hypothesis</title>
+  <link rel="icon" href="favicon.ico" type="image/x-icon" />
+  <style>
+    html {
+      background: #f5f5f5;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100%;
+    }
+
+    body {
+      max-width: 620px;
+      padding: 32px 28px;
+      margin: 40px 16px;
+      background: white;
+      border-radius: 4px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      color: #3f3f3f;
+    }
+
+    .logo {
+      text-align: center;
+      margin-bottom: 24px;
+    }
+
+    h1 {
+      font-size: 20px;
+      margin: 0 0 16px;
+      color: #bd1c2b;
+    }
+
+    p {
+      margin: 0 0 16px;
+    }
+
+    .target-url {
+      display: inline-block;
+      word-break: break-all;
+      font-weight: bold;
+    }
+
+    a {
+      color: #3f3f3f;
+      text-decoration: underline;
+    }
+
+    a:hover {
+      color: #bd1c2b;
+    }
+
+    .link-visit {
+      display: inline-block;
+      margin-top: 8px;
+      padding: 10px 20px;
+      background-color: #3f3f3f;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 3px;
+      font-size: 15px;
+      font-weight: 600;
+    }
+
+    .link-visit:hover {
+      background-color: #bd1c2b;
+      color: #fff;
+    }
+
+    .resources {
+      margin-top: 24px;
+      padding-top: 16px;
+      border-top: 1px solid #e0e0e0;
+    }
+
+    .resources h2 {
+      font-size: 16px;
+      margin: 0 0 12px;
+    }
+
+    .resources ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .resources li {
+      margin-bottom: 8px;
+    }
+
+    .resources li::before {
+      content: "→ ";
+      color: #bd1c2b;
+    }
+  </style>
+</head>
+<body>
+  <div class="logo">
+    <a href="https://hypothes.is">
+      <svg xmlns="http://www.w3.org/2000/svg"
+        width="80" height="80"
+        viewBox="0 0 24 28"
+        aria-labelledby="logo-title">
+        <title id="logo-title">Hypothesis</title>
+        <g fill="none" fill-rule="evenodd">
+          <path fill="#FFF" fill-rule="nonzero" d="M3.886 3.945H21.03v16.047H3.886z"/>
+          <path d="M0 2.005C0 .898.897 0 2.005 0h19.99C23.102 0 24 .897 24 2.005v19.99A2.005 2.005 0 0 1 21.995 24H2.005A2.005 2.005 0 0 1 0 21.995V2.005zM9 24h6l-3 4-3-4zM7.008 4H4v16h3.008v-4.997C7.008 12.005 8.168 12.01 9 12c1 .007 2.019.06 2.019 2.003V20h3.008v-6.891C14.027 10 12 9.003 10 9.003c-1.99 0-2 0-2.992 1.999V4zM19 19.987c1.105 0 2-.893 2-1.994A1.997 1.997 0 0 0 19 16c-1.105 0-2 .892-2 1.993s.895 1.994 2 1.994z" fill="#3F3F3F"/>
+        </g>
+      </svg>
+    </a>
+  </div>
+
+  <h1>Access to Via is now restricted</h1>
+
+  {% if target_url %}
+  <p>
+    The page you were trying to annotate:<br>
+    <a href="{{ target_url }}" class="target-url">{{ target_url }}</a>
+  </p>
+
+  <p>
+    <a href="{{ target_url }}" class="link-visit">Go to page</a>
+  </p>
+  {% endif %}
+
+  <p>
+    You can still view and create annotations in your browser using our
+    Chrome extension, our Bookmarklet, and on sites that embed Hypothesis.
+  </p>
+
+  <div class="resources">
+    <h2>Learn more</h2>
+    <ul>
+      <li>
+        <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/">
+          Announcement: Changes to Via proxy server
+        </a>
+      </li>
+      <li>
+        <a href="https://web.hypothes.is/help/installing-the-chrome-extension/">
+          Install the Chrome extension
+        </a>
+      </li>
+      <li>
+        <a href="https://web.hypothes.is/help/installing-the-bookmarklet/">
+          Install the Bookmarklet
+        </a>
+      </li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/via/templates/restricted.html.jinja2
+++ b/via/templates/restricted.html.jinja2
@@ -57,48 +57,7 @@
       color: #bd1c2b;
     }
 
-    .link-visit {
-      display: inline-block;
-      margin-top: 8px;
-      padding: 10px 20px;
-      background-color: #3f3f3f;
-      color: #fff;
-      text-decoration: none;
-      border-radius: 3px;
-      font-size: 15px;
-      font-weight: 600;
-    }
 
-    .link-visit:hover {
-      background-color: #bd1c2b;
-      color: #fff;
-    }
-
-    .resources {
-      margin-top: 24px;
-      padding-top: 16px;
-      border-top: 1px solid #e0e0e0;
-    }
-
-    .resources h2 {
-      font-size: 16px;
-      margin: 0 0 12px;
-    }
-
-    .resources ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-
-    .resources li {
-      margin-bottom: 8px;
-    }
-
-    .resources li::before {
-      content: "→ ";
-      color: #bd1c2b;
-    }
   </style>
 </head>
 <body>
@@ -117,43 +76,21 @@
     </a>
   </div>
 
-  <h1>Access to Via is now restricted</h1>
+  <h1>Access to Via is now <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/">restricted</a></h1>
 
   {% if target_url %}
   <p>
-    The page you were trying to annotate:<br>
+    This Via link displayed annotations on this page:<br>
     <a href="{{ target_url }}" class="target-url">{{ target_url }}</a>
-  </p>
-
-  <p>
-    <a href="{{ target_url }}" class="link-visit">Go to page</a>
   </p>
   {% endif %}
 
   <p>
-    You can still view and create annotations in your browser using our
-    Chrome extension, our Bookmarklet, and on sites that embed Hypothesis.
+    You can view annotations on this site and others using our
+    <a href="https://web.hypothes.is/help/installing-the-chrome-extension/">Chrome extension</a>,
+    our <a href="https://web.hypothes.is/help/installing-the-bookmarklet/">Bookmarklet</a>,
+    and on sites that
+    <a href="https://web.hypothes.is/help/embedding-hypothesis-in-websites-and-platforms/">embed Hypothesis</a>.
   </p>
-
-  <div class="resources">
-    <h2>Learn more</h2>
-    <ul>
-      <li>
-        <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/">
-          Announcement: Changes to Via proxy server
-        </a>
-      </li>
-      <li>
-        <a href="https://web.hypothes.is/help/installing-the-chrome-extension/">
-          Install the Chrome extension
-        </a>
-      </li>
-      <li>
-        <a href="https://web.hypothes.is/help/installing-the-bookmarklet/">
-          Install the Bookmarklet
-        </a>
-      </li>
-    </ul>
-  </div>
 </body>
 </html>

--- a/via/views/index.py
+++ b/via/views/index.py
@@ -1,10 +1,58 @@
-from pyramid.view import view_config
+from urllib.parse import urlparse
+
+from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPNotFound
+from pyramid.view import view_config, view_defaults
+
+from via.services import SecureLinkService
 
 
-@view_config(
-    route_name="index",
-    renderer="via:templates/restricted.html.jinja2",
-)
-def index(_context, _request):
-    """Show restricted access page."""
-    return {"target_url": None}
+@view_defaults(route_name="index")
+class IndexViews:
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+        self.enabled = request.registry.settings["enable_front_page"]
+
+    def _is_lms_request(self):
+        """Check if request comes from LMS (has a valid signed URL)."""
+        return self.request.find_service(SecureLinkService).request_is_valid(
+            self.request
+        )
+
+    @view_config(request_method="GET", renderer="via:templates/index.html.jinja2")
+    def get(self):
+        # Allow LMS access, otherwise show restricted page
+        if not self._is_lms_request():
+            self.request.override_renderer = "via:templates/restricted.html.jinja2"
+            return {"target_url": None}
+
+        if not self.enabled:
+            return HTTPNotFound()
+
+        self.request.response.headers["X-Robots-Tag"] = "all"
+
+        return {}
+
+    @view_config(request_method="POST")
+    def post(self):
+        # Allow LMS access, otherwise show restricted page
+        if not self._is_lms_request():
+            self.request.override_renderer = "via:templates/restricted.html.jinja2"
+            return {"target_url": None}
+
+        if not self.enabled:
+            return HTTPNotFound()
+
+        try:
+            url = self.context.url_from_query()
+        except HTTPBadRequest:
+            return HTTPFound(self.request.route_url(route_name="index"))
+
+        parsed = urlparse(url)
+        url_without_query = parsed._replace(query="", fragment="").geturl()
+
+        return HTTPFound(
+            self.request.route_url(
+                route_name="proxy", url=url_without_query, _query=parsed.query
+            )
+        )

--- a/via/views/index.py
+++ b/via/views/index.py
@@ -1,49 +1,10 @@
-from urllib.parse import urlparse
-
-from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPNotFound
-from pyramid.view import view_config, view_defaults
+from pyramid.view import view_config
 
 
-@view_defaults(route_name="index")
-class IndexViews:
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
-        self.enabled = request.registry.settings["enable_front_page"]
-
-    @view_config(request_method="GET", renderer="via:templates/index.html.jinja2")
-    def get(self):
-        if not self.enabled:
-            return HTTPNotFound()
-
-        self.request.response.headers["X-Robots-Tag"] = "all"
-
-        return {}
-
-    @view_config(request_method="POST")
-    def post(self):
-        if not self.enabled:
-            return HTTPNotFound()
-
-        try:
-            url = self.context.url_from_query()
-        except HTTPBadRequest:
-            # If we don't get a URL redirect the user to the index page
-            return HTTPFound(self.request.route_url(route_name="index"))
-
-        # In order to replicate the URL structure from original Via we need to
-        # create a path like this:
-        # http://via.host/http://proxied.site?query=1
-        # This means we need to pop off the query string and then add it
-        # separately from the URL, otherwise we'll get the query string encoded
-        # inside the URL portion of the path.
-
-        # `context.url_from_query` protects us from parsing failing
-        parsed = urlparse(url)
-        url_without_query = parsed._replace(query="", fragment="").geturl()
-
-        return HTTPFound(
-            self.request.route_url(
-                route_name="proxy", url=url_without_query, _query=parsed.query
-            )
-        )
+@view_config(
+    route_name="index",
+    renderer="via:templates/restricted.html.jinja2",
+)
+def index(_context, _request):
+    """Show restricted access page."""
+    return {"target_url": None}

--- a/via/views/index.py
+++ b/via/views/index.py
@@ -15,7 +15,7 @@ class IndexViews:
 
     def _is_lms_request(self):
         """Check if request comes from LMS (has a valid signed URL)."""
-        return self.request.find_service(SecureLinkService).request_is_valid(
+        return self.request.find_service(SecureLinkService).request_has_valid_token(
             self.request
         )
 

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,6 +1,8 @@
 from pyramid.httpexceptions import HTTPGone
 from pyramid.view import view_config
 
+from via.services import SecureLinkService, URLDetailsService, ViaClientService
+
 
 @view_config(route_name="static_fallback")
 def static_fallback(_context, _request):
@@ -11,12 +13,32 @@ def static_fallback(_context, _request):
 
 @view_config(
     route_name="proxy",
-    renderer="via:templates/restricted.html.jinja2",
+    renderer="via:templates/proxy.html.jinja2",
 )
-def proxy(context, _request):
-    try:
-        target_url = context.url_from_path()
-    except Exception:  # noqa: BLE001
-        target_url = None
+def proxy(context, request):
+    """Proxy view.
 
-    return {"target_url": target_url}
+    If the request comes through LMS (valid signed URL), serve the proxy.
+    Otherwise, show the restricted access page.
+    """
+    secure_link_service = request.find_service(SecureLinkService)
+
+    if not secure_link_service.request_is_valid(request):
+        try:
+            target_url = context.url_from_path()
+        except Exception:  # noqa: BLE001
+            target_url = None
+        request.override_renderer = "via:templates/restricted.html.jinja2"
+        return {"target_url": target_url}
+
+    url = context.url_from_path()
+
+    mime_type, _status_code = request.find_service(URLDetailsService).get_url_details(
+        url
+    )
+
+    return {
+        "src": request.find_service(ViaClientService).url_for(
+            url, mime_type, request.params
+        )
+    }

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -1,8 +1,6 @@
 from pyramid.httpexceptions import HTTPGone
 from pyramid.view import view_config
 
-from via.services import URLDetailsService, ViaClientService, has_secure_url_token
-
 
 @view_config(route_name="static_fallback")
 def static_fallback(_context, _request):
@@ -13,18 +11,12 @@ def static_fallback(_context, _request):
 
 @view_config(
     route_name="proxy",
-    renderer="via:templates/proxy.html.jinja2",
-    decorator=(has_secure_url_token,),
+    renderer="via:templates/restricted.html.jinja2",
 )
-def proxy(context, request):
-    url = context.url_from_path()
+def proxy(context, _request):
+    try:
+        target_url = context.url_from_path()
+    except Exception:  # noqa: BLE001
+        target_url = None
 
-    mime_type, _status_code = request.find_service(URLDetailsService).get_url_details(
-        url
-    )
-
-    return {
-        "src": request.find_service(ViaClientService).url_for(
-            url, mime_type, request.params
-        )
-    }
+    return {"target_url": target_url}

--- a/via/views/proxy.py
+++ b/via/views/proxy.py
@@ -23,7 +23,7 @@ def proxy(context, request):
     """
     secure_link_service = request.find_service(SecureLinkService)
 
-    if not secure_link_service.request_is_valid(request):
+    if not secure_link_service.request_has_valid_token(request):
         try:
             target_url = context.url_from_path()
         except Exception:  # noqa: BLE001

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -1,54 +1,17 @@
 """View for redirecting based on content type."""
 
-from h_vialib import ContentType
-from pyramid import httpexceptions as exc
 from pyramid import view
 
-from via.services import URLDetailsService, ViaClientService, has_secure_url_token
 
+@view.view_config(
+    route_name="route_by_content",
+    renderer="via:templates/restricted.html.jinja2",
+)
+def route_by_content(context, _request):
+    """Show restricted access page instead of routing content."""
+    try:
+        target_url = context.url_from_query()
+    except Exception:  # noqa: BLE001
+        target_url = None
 
-@view.view_config(route_name="route_by_content", decorator=(has_secure_url_token,))
-def route_by_content(context, request):
-    """Routes the request according to the Content-Type header."""
-    url = context.url_from_query()
-
-    mime_type, status_code = request.find_service(URLDetailsService).get_url_details(
-        url, request.headers
-    )
-    via_client_svc = request.find_service(ViaClientService)
-
-    if via_client_svc.content_type(mime_type) in (ContentType.PDF, ContentType.YOUTUBE):
-        caching_headers = _caching_headers(max_age=300)
-    else:
-        caching_headers = _cache_headers_for_http(status_code)
-
-    params = dict(request.params)
-    params.pop("url", None)
-
-    url = via_client_svc.url_for(url, mime_type, params)
-
-    return exc.HTTPFound(url, headers=caching_headers)
-
-
-def _cache_headers_for_http(status_code):
-    if status_code == 404:
-        # 404 - A rare case we may want to handle differently, as unusually
-        # for a 4xx error, trying again can help if it becomes available
-        return _caching_headers(max_age=60)
-
-    if status_code < 500:
-        # 2xx - OK
-        # 3xx - we follow it, so this shouldn't happen
-        # 4xx - no point in trying again quickly
-        return _caching_headers(max_age=60)
-
-    # 5xx - Errors should not be cached
-    return {"Cache-Control": "no-cache"}
-
-
-def _caching_headers(max_age, stale_while_revalidate=86400):
-    # I tried using webob.CacheControl for this but it's total rubbish
-    header = (
-        f"public, max-age={max_age}, stale-while-revalidate={stale_while_revalidate}"
-    )
-    return {"Cache-Control": header}
+    return {"target_url": target_url}

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -1,17 +1,62 @@
 """View for redirecting based on content type."""
 
+from h_vialib import ContentType
+from pyramid import httpexceptions as exc
 from pyramid import view
 
+from via.services import SecureLinkService, URLDetailsService, ViaClientService
 
-@view.view_config(
-    route_name="route_by_content",
-    renderer="via:templates/restricted.html.jinja2",
-)
-def route_by_content(context, _request):
-    """Show restricted access page instead of routing content."""
-    try:
-        target_url = context.url_from_query()
-    except Exception:  # noqa: BLE001
-        target_url = None
 
-    return {"target_url": target_url}
+@view.view_config(route_name="route_by_content")
+def route_by_content(context, request):
+    """Routes the request according to the Content-Type header.
+
+    If the request comes through LMS (has a valid signed URL), serve the
+    original routing logic. Otherwise, show the restricted access page.
+    """
+    secure_link_service = request.find_service(SecureLinkService)
+
+    if not secure_link_service.request_is_valid(request):
+        try:
+            target_url = context.url_from_query()
+        except Exception:  # noqa: BLE001
+            target_url = None
+
+        request.override_renderer = "via:templates/restricted.html.jinja2"
+        return {"target_url": target_url}
+
+    url = context.url_from_query()
+
+    mime_type, status_code = request.find_service(URLDetailsService).get_url_details(
+        url, request.headers
+    )
+    via_client_svc = request.find_service(ViaClientService)
+
+    if via_client_svc.content_type(mime_type) in (ContentType.PDF, ContentType.YOUTUBE):
+        caching_headers = _caching_headers(max_age=300)
+    else:
+        caching_headers = _cache_headers_for_http(status_code)
+
+    params = dict(request.params)
+    params.pop("url", None)
+
+    url = via_client_svc.url_for(url, mime_type, params)
+
+    return exc.HTTPFound(url, headers=caching_headers)
+
+
+def _cache_headers_for_http(status_code):
+    if status_code == 404:
+        return _caching_headers(max_age=60)
+
+    if status_code < 500:
+        return _caching_headers(max_age=60)
+
+    return {"Cache-Control": "no-cache"}
+
+
+def _caching_headers(max_age, stale_while_revalidate=86400):
+    header = (
+        f"public, max-age={max_age}, stale-while-revalidate={stale_while_revalidate}"
+    )
+    return {"Cache-Control": header}

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -16,7 +16,7 @@ def route_by_content(context, request):
     """
     secure_link_service = request.find_service(SecureLinkService)
 
-    if not secure_link_service.request_is_valid(request):
+    if not secure_link_service.request_has_valid_token(request):
         try:
             target_url = context.url_from_query()
         except Exception:  # noqa: BLE001

--- a/via/views/route_by_content.py
+++ b/via/views/route_by_content.py
@@ -7,7 +7,10 @@ from pyramid import view
 from via.services import SecureLinkService, URLDetailsService, ViaClientService
 
 
-@view.view_config(route_name="route_by_content")
+@view.view_config(
+    route_name="route_by_content",
+    renderer="via:templates/restricted.html.jinja2",
+)
 def route_by_content(context, request):
     """Routes the request according to the Content-Type header.
 

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -8,7 +8,12 @@ from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
 from via.requests_tools.headers import add_request_headers
-from via.services import CheckmateService, GoogleDriveAPI, HTTPService, SecureLinkService
+from via.services import (
+    CheckmateService,
+    GoogleDriveAPI,
+    HTTPService,
+    SecureLinkService,
+)
 from via.services.pdf_url import PDFURLBuilder
 
 

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -14,7 +14,7 @@ from via.services.pdf_url import PDFURLBuilder
 
 def _is_lms_request(request):
     """Check if request comes from LMS (has a valid signed URL)."""
-    return request.find_service(SecureLinkService).request_is_valid(request)
+    return request.find_service(SecureLinkService).request_has_valid_token(request)
 
 
 def _restricted_response(request, context=None):

--- a/via/views/view_pdf.py
+++ b/via/views/view_pdf.py
@@ -1,52 +1,122 @@
 """View presenting the PDF viewer."""
 
+from itertools import chain
+
+from h_vialib import Configuration
+from h_vialib.secure import Encryption
+from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
+from via.requests_tools.headers import add_request_headers
+from via.services import CheckmateService, GoogleDriveAPI, HTTPService, SecureLinkService
+from via.services.pdf_url import PDFURLBuilder
+
+
+def _is_lms_request(request):
+    """Check if request comes from LMS (has a valid signed URL)."""
+    return request.find_service(SecureLinkService).request_is_valid(request)
+
+
+def _restricted_response(request, context=None):
+    """Return the restricted access page response."""
+    try:
+        target_url = context.url_from_query() if context else None
+    except Exception:  # noqa: BLE001
+        target_url = None
+    request.override_renderer = "via:templates/restricted.html.jinja2"
+    return {"target_url": target_url}
+
 
 @view_config(
-    renderer="via:templates/restricted.html.jinja2",
+    renderer="via:templates/pdf_viewer.html.jinja2",
     route_name="view_pdf",
+    http_cache=0,
 )
-def view_pdf(context, _request):
-    """Show restricted access page instead of the PDF viewer."""
+def view_pdf(context, request):
+    """HTML page with client and the PDF embedded.
+
+    If the request comes through LMS (valid signed URL), serve the PDF viewer.
+    Otherwise, show the restricted access page.
+    """
+    if not _is_lms_request(request):
+        return _restricted_response(request, context)
+
+    url = context.url_from_query()
+    checkmate_service = request.find_service(CheckmateService)
+
+    checkmate_service.raise_if_blocked(url)
+
+    _, h_config = Configuration.extract_from_params(request.params)
+
+    return {
+        "pdf_url": url,
+        "proxy_pdf_url": request.find_service(PDFURLBuilder).get_pdf_url(url),
+        "client_embed_url": request.registry.settings["client_embed_url"],
+        "static_url": request.static_url,
+        "hypothesis_config": h_config,
+    }
+
+
+@view_config(route_name="proxy_onedrive_pdf")
+@view_config(route_name="proxy_d2l_pdf")
+@view_config(route_name="proxy_python_pdf")
+def proxy_python_pdf(context, request):
+    """Proxy a pdf with python (as opposed to nginx).
+
+    If the request comes through LMS (valid signed URL), proxy the PDF.
+    Otherwise, show the restricted access page.
+    """
+    if not _is_lms_request(request):
+        return _restricted_response(request, context)
+
+    url = context.url_from_query()
+    params = {}
+    if "via.secret.query" in request.params:
+        secure_secrets = Encryption(
+            request.registry.settings["via_secret"].encode("utf-8")
+        )
+        params = secure_secrets.decrypt_dict(request.params["via.secret.query"])
+
+    content_iterable = request.find_service(HTTPService).stream(
+        url, headers=add_request_headers({}, request=request), params=params
+    )
+
+    return _iter_pdf_response(request.response, content_iterable)
+
+
+@view_config(route_name="proxy_google_drive_file")
+@view_config(route_name="proxy_google_drive_file:resource_key")
+def proxy_google_drive_file(request):
+    """Proxy a file from Google Drive.
+
+    If the request comes through LMS (valid signed URL), proxy the file.
+    Otherwise, show the restricted access page.
+    """
+    if not _is_lms_request(request):
+        request.override_renderer = "via:templates/restricted.html.jinja2"
+        return {"target_url": None}
+
+    content_iterable = request.find_service(GoogleDriveAPI).iter_file(
+        file_id=request.matchdict["file_id"],
+        resource_key=request.matchdict.get("resource_key"),
+    )
+
+    return _iter_pdf_response(request.response, content_iterable)
+
+
+def _iter_pdf_response(response, content_iterable):
     try:
-        target_url = context.url_from_query()
-    except Exception:  # noqa: BLE001
-        target_url = None
+        content_iterable = chain((next(content_iterable),), content_iterable)
+    except StopIteration:
+        return HTTPNoContent()
 
-    return {"target_url": target_url}
+    response.headers.update(
+        {
+            "Content-Disposition": "inline",
+            "Content-Type": "application/pdf",
+            "Cache-Control": "public, max-age=43200, stale-while-revalidate=86400",
+        }
+    )
 
-
-@view_config(
-    route_name="proxy_onedrive_pdf",
-    renderer="via:templates/restricted.html.jinja2",
-)
-@view_config(
-    route_name="proxy_d2l_pdf",
-    renderer="via:templates/restricted.html.jinja2",
-)
-@view_config(
-    route_name="proxy_python_pdf",
-    renderer="via:templates/restricted.html.jinja2",
-)
-def proxy_python_pdf(context, _request):
-    """Show restricted access page instead of proxying PDF."""
-    try:
-        target_url = context.url_from_query()
-    except Exception:  # noqa: BLE001
-        target_url = None
-
-    return {"target_url": target_url}
-
-
-@view_config(
-    route_name="proxy_google_drive_file",
-    renderer="via:templates/restricted.html.jinja2",
-)
-@view_config(
-    route_name="proxy_google_drive_file:resource_key",
-    renderer="via:templates/restricted.html.jinja2",
-)
-def proxy_google_drive_file(_request):
-    """Show restricted access page instead of proxying Google Drive file."""
-    return {"target_url": None}
+    response.app_iter = content_iterable
+    return response

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -1,103 +1,25 @@
-import marshmallow
-from h_vialib import Configuration
-from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
-from webargs import fields
-from webargs.pyramidparser import use_kwargs
-
-from via.exceptions import BadURL
-from via.security import ViaSecurityPolicy
-from via.services import YouTubeService
 
 
-def _api_headers(request):
-    """Return common headers for API requests."""
-    jwt = ViaSecurityPolicy.encode_jwt(request)
-    return {"Authorization": f"Bearer {jwt}"}
-
-
-@view_config(renderer="via:templates/view_video.html.jinja2", route_name="youtube")
-@use_kwargs(
-    {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.INCLUDE
+@view_config(
+    renderer="via:templates/restricted.html.jinja2",
+    route_name="youtube",
 )
-def youtube(request, url, **kwargs):
-    youtube_service = request.find_service(YouTubeService)
+def youtube(context, _request):
+    """Show restricted access page instead of the YouTube viewer."""
+    try:
+        target_url = context.url_from_query()
+    except Exception:  # noqa: BLE001
+        target_url = None
 
-    if not youtube_service.enabled:
-        raise HTTPUnauthorized()  # noqa: RSE102
-
-    video_id = youtube_service.get_video_id(url)
-    video_url = youtube_service.canonical_video_url(video_id)
-    video_title = youtube_service.get_video_title(video_id)
-
-    if not video_id:
-        raise BadURL(f"Unsupported video URL: {url}", url=url)  # noqa: EM102, TRY003
-
-    _, client_config = Configuration.extract_from_params(kwargs)
-
-    return {
-        # Common video player fields
-        "client_embed_url": request.registry.settings["client_embed_url"],
-        "client_config": client_config,
-        "player": "youtube",
-        "title": video_title,
-        "video_url": video_url,
-        "api": {
-            "transcript": {
-                "doc": "Get the transcript of the current video",
-                "url": request.route_url("api.youtube.transcript", video_id=video_id),
-                "method": "GET",
-                "headers": _api_headers(request),
-            }
-        },
-        # Fields specific to YouTube video player
-        "video_id": video_id,
-    }
+    return {"target_url": target_url}
 
 
 @view_config(
     route_name="video",
-    renderer="via:templates/view_video.html.jinja2",
+    renderer="via:templates/restricted.html.jinja2",
 )
-@use_kwargs(
-    {
-        "url": fields.Url(required=True),
-        "media_url": fields.Url(required=False),
-        "transcript": fields.Url(required=True),
-        "title": fields.Str(required=False),
-        "allow_download": fields.Boolean(required=False),
-    },
-    location="query",
-    unknown=marshmallow.INCLUDE,
-)
-def video(request, **kwargs):
-    allow_download = kwargs.get("allow_download", True)
-    url = kwargs["url"]
-    media_url = kwargs.get("media_url")
-    transcript = kwargs["transcript"]
-
-    video_title = kwargs.get("title") or "Video"
-    media_url = media_url or url
-    _, client_config = Configuration.extract_from_params(kwargs)
-
-    return {
-        # Common video player fields
-        "client_embed_url": request.registry.settings["client_embed_url"],
-        "client_config": client_config,
-        "player": "html-video",
-        "title": video_title,
-        "video_url": url,
-        "api": {
-            "transcript": {
-                "doc": "Get the transcript of the current video",
-                "url": request.route_url(
-                    "api.video.transcript", _query={"url": transcript}
-                ),
-                "method": "GET",
-                "headers": _api_headers(request),
-            },
-        },
-        # Fields specific to HTML video player.
-        "allow_download": allow_download,
-        "video_src": media_url,
-    }
+def video(_context, request):
+    """Show restricted access page instead of the video viewer."""
+    target_url = request.params.get("url")
+    return {"target_url": target_url}

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -12,7 +12,7 @@ from via.services import SecureLinkService, YouTubeService
 
 def _is_lms_request(request):
     """Check if request comes from LMS (has a valid signed URL)."""
-    return request.find_service(SecureLinkService).request_is_valid(request)
+    return request.find_service(SecureLinkService).request_has_valid_token(request)
 
 
 def _restricted_response(request, target_url=None):

--- a/via/views/view_video.py
+++ b/via/views/view_video.py
@@ -1,25 +1,127 @@
+import marshmallow
+from h_vialib import Configuration
+from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
+from webargs import fields
+from webargs.pyramidparser import use_kwargs
+
+from via.exceptions import BadURL
+from via.security import ViaSecurityPolicy
+from via.services import SecureLinkService, YouTubeService
 
 
-@view_config(
-    renderer="via:templates/restricted.html.jinja2",
-    route_name="youtube",
-)
-def youtube(context, _request):
-    """Show restricted access page instead of the YouTube viewer."""
-    try:
-        target_url = context.url_from_query()
-    except Exception:  # noqa: BLE001
-        target_url = None
+def _is_lms_request(request):
+    """Check if request comes from LMS (has a valid signed URL)."""
+    return request.find_service(SecureLinkService).request_is_valid(request)
 
+
+def _restricted_response(request, target_url=None):
+    """Return the restricted access page response."""
+    request.override_renderer = "via:templates/restricted.html.jinja2"
     return {"target_url": target_url}
+
+
+def _api_headers(request):
+    """Return common headers for API requests."""
+    jwt = ViaSecurityPolicy.encode_jwt(request)
+    return {"Authorization": f"Bearer {jwt}"}
+
+
+@view_config(renderer="via:templates/view_video.html.jinja2", route_name="youtube")
+@use_kwargs(
+    {"url": fields.Url(required=True)}, location="query", unknown=marshmallow.INCLUDE
+)
+def youtube(request, url, **kwargs):
+    """YouTube video viewer.
+
+    If the request comes through LMS (valid signed URL), serve the viewer.
+    Otherwise, show the restricted access page.
+    """
+    if not _is_lms_request(request):
+        return _restricted_response(request, target_url=url)
+
+    youtube_service = request.find_service(YouTubeService)
+
+    if not youtube_service.enabled:
+        raise HTTPUnauthorized()  # noqa: RSE102
+
+    video_id = youtube_service.get_video_id(url)
+    video_url = youtube_service.canonical_video_url(video_id)
+    video_title = youtube_service.get_video_title(video_id)
+
+    if not video_id:
+        raise BadURL(f"Unsupported video URL: {url}", url=url)  # noqa: EM102, TRY003
+
+    _, client_config = Configuration.extract_from_params(kwargs)
+
+    return {
+        "client_embed_url": request.registry.settings["client_embed_url"],
+        "client_config": client_config,
+        "player": "youtube",
+        "title": video_title,
+        "video_url": video_url,
+        "api": {
+            "transcript": {
+                "doc": "Get the transcript of the current video",
+                "url": request.route_url("api.youtube.transcript", video_id=video_id),
+                "method": "GET",
+                "headers": _api_headers(request),
+            }
+        },
+        "video_id": video_id,
+    }
 
 
 @view_config(
     route_name="video",
-    renderer="via:templates/restricted.html.jinja2",
+    renderer="via:templates/view_video.html.jinja2",
 )
-def video(_context, request):
-    """Show restricted access page instead of the video viewer."""
-    target_url = request.params.get("url")
-    return {"target_url": target_url}
+@use_kwargs(
+    {
+        "url": fields.Url(required=True),
+        "media_url": fields.Url(required=False),
+        "transcript": fields.Url(required=True),
+        "title": fields.Str(required=False),
+        "allow_download": fields.Boolean(required=False),
+    },
+    location="query",
+    unknown=marshmallow.INCLUDE,
+)
+def video(request, **kwargs):
+    """HTML video viewer.
+
+    If the request comes through LMS (valid signed URL), serve the viewer.
+    Otherwise, show the restricted access page.
+    """
+    if not _is_lms_request(request):
+        target_url = kwargs.get("url")
+        return _restricted_response(request, target_url=target_url)
+
+    allow_download = kwargs.get("allow_download", True)
+    url = kwargs["url"]
+    media_url = kwargs.get("media_url")
+    transcript = kwargs["transcript"]
+
+    video_title = kwargs.get("title") or "Video"
+    media_url = media_url or url
+    _, client_config = Configuration.extract_from_params(kwargs)
+
+    return {
+        "client_embed_url": request.registry.settings["client_embed_url"],
+        "client_config": client_config,
+        "player": "html-video",
+        "title": video_title,
+        "video_url": url,
+        "api": {
+            "transcript": {
+                "doc": "Get the transcript of the current video",
+                "url": request.route_url(
+                    "api.video.transcript", _query={"url": transcript}
+                ),
+                "method": "GET",
+                "headers": _api_headers(request),
+            },
+        },
+        "allow_download": allow_download,
+        "video_src": media_url,
+    }


### PR DESCRIPTION
This pull request implements a major change to Via's behavior: all routes that previously rendered or proxied content (including PDFs, videos, and general web pages) now display a restricted access page instead. The new `restricted.html.jinja2` template informs users that Via is no longer available for annotation and provides alternative resources. All previous view logic for content routing, proxying, and rendering has been removed or replaced with simple views that render the restricted page.

https://github.com/hypothesis/product-backlog/issues/1708

Restricted access enforcement across all routes:

* Replaced the rendering logic in `via/views/index.py`, `via/views/proxy.py`, `via/views/route_by_content.py`, `via/views/view_pdf.py`, and `via/views/view_video.py` to display the restricted access page using the new `via:templates/restricted.html.jinja2` template. All routes now return a context containing the attempted target URL when possible. [[1]](diffhunk://#diff-57efeaa8297523c02ad528b92f180f86c22bd33096ecf07887c0c7764ddf1c52L1-R10) [[2]](diffhunk://#diff-d4828f1896cb822bb0184e4690a91a150aa8b61a40d1d3c85f77eba3cda08324L4-L5) [[3]](diffhunk://#diff-d4828f1896cb822bb0184e4690a91a150aa8b61a40d1d3c85f77eba3cda08324L16-R22) [[4]](diffhunk://#diff-5f32fec7e2e24f61cd7197ea8d6ae874885bf26739bc075082b5d56cb616a474L3-R17) [[5]](diffhunk://#diff-48cd0006230d230d4dba09080a772e52e0a1670dabfc3dfda67495aba675c3c3L3-R52) [[6]](diffhunk://#diff-46ca6ec66a757a5b4c23e900c85139ce85cd917c0555fba79c2d670cc411bc15L1-R25)

Removal of legacy content handling logic:

* Removed all previous logic for handling, proxying, and rendering content—including PDF viewer, video viewer, Google Drive proxy, and content-type routing. Views now simply render the restricted access page and no longer process or stream content. [[1]](diffhunk://#diff-48cd0006230d230d4dba09080a772e52e0a1670dabfc3dfda67495aba675c3c3L3-R52) [[2]](diffhunk://#diff-46ca6ec66a757a5b4c23e900c85139ce85cd917c0555fba79c2d670cc411bc15L1-R25) [[3]](diffhunk://#diff-5f32fec7e2e24f61cd7197ea8d6ae874885bf26739bc075082b5d56cb616a474L3-R17) [[4]](diffhunk://#diff-d4828f1896cb822bb0184e4690a91a150aa8b61a40d1d3c85f77eba3cda08324L4-L5) [[5]](diffhunk://#diff-d4828f1896cb822bb0184e4690a91a150aa8b61a40d1d3c85f77eba3cda08324L16-R22)

Addition of restricted access template:

* Added a new `via/templates/restricted.html.jinja2` template that provides a user-friendly message about Via's restricted access, displays the attempted URL, and offers links to alternative annotation tools and relevant resources.

These changes ensure that Via no longer serves or proxies content, but instead guides users to alternative annotation methods and informs them about the change.