### PR TITLE
Remove via access

### DIFF
--- a/via/templates/index.html.jinja2
+++ b/via/templates/index.html.jinja2
@@ -93,26 +93,15 @@
         <g fill="none" fill-rule="evenodd"><path fill="#FFF" fill-rule="nonzero" d="M3.886 3.945H21.03v16.047H3.886z"/><path d="M0 2.005C0 .898.897 0 2.005 0h19.99C23.102 0 24 .897 24 2.005v19.99A2.005 2.005 0 0 1 21.995 24H2.005A2.005 2.005 0 0 1 0 21.995V2.005zM9 24h6l-3 4-3-4zM7.008 4H4v16h3.008v-4.997C7.008 12.005 8.168 12.01 9 12c1 .007 2.019.06 2.019 2.003V20h3.008v-6.891C14.027 10 12 9.003 10 9.003c-1.99 0-2 0-2.992 1.999V4zM19 19.987c1.105 0 2-.893 2-1.994A1.997 1.997 0 0 0 19 16c-1.105 0-2 .892-2 1.993s.895 1.994 2 1.994z" fill="#3F3F3F"/></g>
       </svg>
     </a>
-    <form class="url-form" method="post" novalidate>
-      <input id="search"
-             aria-label="Web or PDF document to annotate"
-             autofocus
-             class="url-field"
-             name="url"
-             placeholder="Paste a link to annotate"
-             type="url"
-           >
-      <button type="submit" class="annotate-btn">Annotate</button>
-
+    <div class="url-form">
       <p>
-        Via is a closed proxy that lets you annotate web pages and PDFs with
-        Hypothesis. Only a small number of known sites can be annotated.
-        See our
-        <a href="https://web.hypothes.is/help/what-is-the-via-proxy/">help article</a>
-        and <a href="https://web.hypothes.is/abuse-policy/">abuse policy</a>
-        for more information.
+        <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/">Access to Via is now restricted</a>.
+        You can view annotations in your browser using our
+        <a href="https://web.hypothes.is/help/installing-the-chrome-extension/">Chrome extension</a>,
+        our <a href="https://web.hypothes.is/help/installing-the-bookmarklet/">Bookmarklet</a>,
+        and on sites that embed Hypothesis.
       </p>
-    </form>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
This pull request updates the `index.html.jinja2` template to reflect recent changes in access to the Via proxy service. The main change is the removal of the URL submission form and the addition of new messaging that directs users to alternative ways to annotate web pages and PDFs.



#1708 

Access and user guidance updates:

* Removed the URL submission form and replaced it with a notice about restricted access to Via, including a link to a blog post explaining the change.
* Updated instructions to direct users to use the Chrome extension, Bookmarklet, or sites that embed Hypothesis for annotation, instead of Via.