### PR TITLE
chore(deps): bump @vitest/* group to 4.1.9 (Vanta critical remediation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "@hypothesis/frontend-testing": "^1.8.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/youtube": "^0.1.2",
-    "@vitest/browser": "^4.1.8",
-    "@vitest/browser-playwright": "^4.1.7",
-    "@vitest/coverage-istanbul": "^4.1.7",
+    "@vitest/browser": "^4.1.9",
+    "@vitest/browser-playwright": "^4.1.9",
+    "@vitest/coverage-istanbul": "^4.1.9",
     "@vitest/eslint-plugin": "^1.6.18",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-mockable-imports": "^2.0.1",
@@ -58,7 +58,7 @@
     "sinon": "^19.0.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.53.1",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.9"
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,62 +3387,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/browser-playwright@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/browser-playwright@npm:4.1.7"
+"@vitest/browser-playwright@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/browser-playwright@npm:4.1.9"
   dependencies:
-    "@vitest/browser": 4.1.7
-    "@vitest/mocker": 4.1.7
+    "@vitest/browser": 4.1.9
+    "@vitest/mocker": 4.1.9
     tinyrainbow: ^3.1.0
   peerDependencies:
     playwright: "*"
-    vitest: 4.1.7
+    vitest: 4.1.9
   peerDependenciesMeta:
     playwright:
       optional: false
-  checksum: ae86a6a8911ebfa4e334e8b09a94c2949f1b96a42c50c147d5f600fa47bc37c8034f55e7633762118ecef3951d57b24886f3f0057ec6028498ba86cb0863fc98
+  checksum: 5ae7619a667448d488a5ff2345f7ab874df206de25ca0251c91d597257970aee23fc81c262cfde5d55a1eeb51e85b7220fd51bc541c328adca1471f9b73331e9
   languageName: node
   linkType: hard
 
-"@vitest/browser@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/browser@npm:4.1.7"
+"@vitest/browser@npm:4.1.9, @vitest/browser@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/browser@npm:4.1.9"
   dependencies:
     "@blazediff/core": 1.9.1
-    "@vitest/mocker": 4.1.7
-    "@vitest/utils": 4.1.7
+    "@vitest/mocker": 4.1.9
+    "@vitest/utils": 4.1.9
     magic-string: ^0.30.21
     pngjs: ^7.0.0
     sirv: ^3.0.2
     tinyrainbow: ^3.1.0
     ws: ^8.19.0
   peerDependencies:
-    vitest: 4.1.7
-  checksum: 23b633eafb53de936e8d94ca8bfe89136dedcb3641ab1f8b1b514ca013df56b73affe434c9798af94b2f164763da6c06fa1e1a1ff798407f9c38e15e0bd46a85
+    vitest: 4.1.9
+  checksum: 72acbf03c3675ddf3075485a60a515a1ab7512bbd02b67044d06f63c1fbda2d42ab31af7094aa987640fcc2cf9d643800359bc475bc920d66c767d16794264d8
   languageName: node
   linkType: hard
 
-"@vitest/browser@npm:^4.1.8":
-  version: 4.1.8
-  resolution: "@vitest/browser@npm:4.1.8"
-  dependencies:
-    "@blazediff/core": 1.9.1
-    "@vitest/mocker": 4.1.8
-    "@vitest/utils": 4.1.8
-    magic-string: ^0.30.21
-    pngjs: ^7.0.0
-    sirv: ^3.0.2
-    tinyrainbow: ^3.1.0
-    ws: ^8.19.0
-  peerDependencies:
-    vitest: 4.1.8
-  checksum: fd237f64244cd80d815c45b76349544f9540a30ec77b357f40d005f5cc754b3db8915c1c9412b267132a3ad3926a454af1cd99c2eac50f7a6c50761f9ad0bb29
-  languageName: node
-  linkType: hard
-
-"@vitest/coverage-istanbul@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/coverage-istanbul@npm:4.1.7"
+"@vitest/coverage-istanbul@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/coverage-istanbul@npm:4.1.9"
   dependencies:
     "@babel/core": ^7.29.0
     "@istanbuljs/schema": ^0.1.3
@@ -3455,8 +3437,8 @@ __metadata:
     obug: ^2.1.1
     tinyrainbow: ^3.1.0
   peerDependencies:
-    vitest: 4.1.7
-  checksum: 5edac9d7c107e2d17ce5ac75f84dbcd91c636c784fa33c586332a5bc1cc4e9f5f030ec64f52e8a176a1af83adccac736591c11ab9c3728b067cd74219af15983
+    vitest: 4.1.9
+  checksum: 71883767de0b593f6bc98219848a194f27bfe2b58cfd7006248bce09a7bc359d8206e04d8f297098b4221ddc623015de898f6a299ad1221f16543659e4d6f094
   languageName: node
   linkType: hard
 
@@ -3482,25 +3464,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/expect@npm:4.1.7"
+"@vitest/expect@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/expect@npm:4.1.9"
   dependencies:
     "@standard-schema/spec": ^1.1.0
     "@types/chai": ^5.2.2
-    "@vitest/spy": 4.1.7
-    "@vitest/utils": 4.1.7
+    "@vitest/spy": 4.1.9
+    "@vitest/utils": 4.1.9
     chai: ^6.2.2
     tinyrainbow: ^3.1.0
-  checksum: fe9ced5f3d3a0681d41b8a78c7b9329fde92a88b21176e943f01cd820d120cda622d380f0118d87cdcab60a92ac9141f5ef07eabdd3672995370e1a8adf13e7a
+  checksum: 0f536185533423eec1988fb6e3391688fe913ab1d9542be3e1ea3d164e0aecec541851b06e5d95026525fcf1c40600e94364d64f115495a325104b98b7f2f4a4
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/mocker@npm:4.1.7"
+"@vitest/mocker@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/mocker@npm:4.1.9"
   dependencies:
-    "@vitest/spy": 4.1.7
+    "@vitest/spy": 4.1.9
     estree-walker: ^3.0.3
     magic-string: ^0.30.21
   peerDependencies:
@@ -3511,102 +3493,56 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 1c7bd6419ff9245c203e4218a3207e346247b8c4a2a48db4b19bdeb679e59eb580bf98615c7cd21c072d653c75b1484028e60f5de284fa2f0ee2986cc717f73c
+  checksum: 0c3f0a1e369deaea95450802b151d6edfcd795966a17a5c97f36ea7c03231763410d36ae5571042ab089b58a89c9f8ef5d0d6591afea80ac1fb093ae211ae00d
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.8":
-  version: 4.1.8
-  resolution: "@vitest/mocker@npm:4.1.8"
-  dependencies:
-    "@vitest/spy": 4.1.8
-    estree-walker: ^3.0.3
-    magic-string: ^0.30.21
-  peerDependencies:
-    msw: ^2.4.9
-    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    msw:
-      optional: true
-    vite:
-      optional: true
-  checksum: f364ea6b0de73822b57cbfac993e3b3e0eea7fff76ebc8e0e00d16056abb214298adad40a048b118f5df3a025c5a2a870c5c4dc636dcd7796b837a29807b6e4d
-  languageName: node
-  linkType: hard
-
-"@vitest/pretty-format@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/pretty-format@npm:4.1.7"
+"@vitest/pretty-format@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/pretty-format@npm:4.1.9"
   dependencies:
     tinyrainbow: ^3.1.0
-  checksum: 6689c68406df51acec5286b3499e5c1fc15d898f652e6cec2d0f63d90e015842ececcffea7172051a128c55d913f4fd27029409d90bdd2b7bfa3aed56af214d0
+  checksum: 36c07a46d1354d76b599deac41783dabeeffc2fd62881da4fcccb25e4b5d2fe9d62950602c1daeecd3a9fa33447fc33986baf89b62655a32b1d1472e57562918
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.8":
-  version: 4.1.8
-  resolution: "@vitest/pretty-format@npm:4.1.8"
+"@vitest/runner@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/runner@npm:4.1.9"
   dependencies:
-    tinyrainbow: ^3.1.0
-  checksum: fc9706c652b370ffe111fdd8d9246ee57f1f326817528c9166c14f78d55e0fe4f3efd98ec46950fdc101306ab77827cedd08214d46bb0544ec8e4b3561297265
-  languageName: node
-  linkType: hard
-
-"@vitest/runner@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/runner@npm:4.1.7"
-  dependencies:
-    "@vitest/utils": 4.1.7
+    "@vitest/utils": 4.1.9
     pathe: ^2.0.3
-  checksum: e3b575c179a7aacf4f378a35a838c8deddc7e3260990a38fbf847e14e55f9235fb8214506c42e82a87fd920d82773a5c3e2a933e9084152896787948ec4b8e76
+  checksum: e612bac4aaa4e80e719440e0fdaa5249590806d9db7fb01d23a406c1dad3302014b065a4bd4f2b3cb192a789a0d6ef92164d7ea1c1e7de664b9e66e82420b483
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/snapshot@npm:4.1.7"
+"@vitest/snapshot@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/snapshot@npm:4.1.9"
   dependencies:
-    "@vitest/pretty-format": 4.1.7
-    "@vitest/utils": 4.1.7
+    "@vitest/pretty-format": 4.1.9
+    "@vitest/utils": 4.1.9
     magic-string: ^0.30.21
     pathe: ^2.0.3
-  checksum: 144086dab6ae8d62301ecf0013129ac4d5558736ddb198c8c782d9e157193f8ed52dfa0bf42a8f16348b15019797070a0738f6003b6e090f64adf1902ae39721
+  checksum: 84305e3053f05f029500e85c9f60f682edbe1750982bb69add9e06ab82d1d1718fa13098132fbf0cab54e6c2866633b8f235258a285a2e3c87973f6e6179c520
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/spy@npm:4.1.7"
-  checksum: f13c176be51398a5f7440190095947102ca7edbe67c0b86ae651b81c233b6a9075e1c13c53dd8cadd981f797ec622241ee8a71d30588937646a631e930fe79af
+"@vitest/spy@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/spy@npm:4.1.9"
+  checksum: 1450cc1a6863fb67342e043741b1f8fd3a74182b54776770cc3578e33d84e107f8e4254c0a69bce76893c0b511a5ff57af3ab07f953530bbb8dae0e8176e10f6
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.8":
-  version: 4.1.8
-  resolution: "@vitest/spy@npm:4.1.8"
-  checksum: d91fb91357979e1a8d026d1d3dbafbac4c9b80e6cae94b859bed64f45d4d52750f593a4135718d2fdacb1405935231590947546062a8b494730c825a3e7578b1
-  languageName: node
-  linkType: hard
-
-"@vitest/utils@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/utils@npm:4.1.7"
+"@vitest/utils@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/utils@npm:4.1.9"
   dependencies:
-    "@vitest/pretty-format": 4.1.7
+    "@vitest/pretty-format": 4.1.9
     convert-source-map: ^2.0.0
     tinyrainbow: ^3.1.0
-  checksum: ca207f317c416bdf0d61222ce4501ccbfaf1ab3ec1d2c0f37163b48c17567dba937814a3661983d3fb53b6e3ad747b2977c3877555ed3c83df8361c6ab024195
-  languageName: node
-  linkType: hard
-
-"@vitest/utils@npm:4.1.8":
-  version: 4.1.8
-  resolution: "@vitest/utils@npm:4.1.8"
-  dependencies:
-    "@vitest/pretty-format": 4.1.8
-    convert-source-map: ^2.0.0
-    tinyrainbow: ^3.1.0
-  checksum: aa9a05ffd8e41c4899a45e876501b7401d5c95cb29dee0285f0b5930cdc6b717a0dd1d3d7144e90a6114d03590d54ade6a93dd23bbf0b7936be24ca6e4e80f42
+  checksum: fc18fbbe2e7360f6e518ef30ca237e18be6f99897705046d018606dc22cf9be18fc69b31c778affdaadb336f7fef4de94f6c9bdbf5ac2321a4a034941fe152e7
   languageName: node
   linkType: hard
 
@@ -9496,9 +9432,9 @@ __metadata:
     "@tailwindcss/postcss": ^4.1.17
     "@trivago/prettier-plugin-sort-imports": ^5.2.2
     "@types/youtube": ^0.1.2
-    "@vitest/browser": ^4.1.8
-    "@vitest/browser-playwright": ^4.1.7
-    "@vitest/coverage-istanbul": ^4.1.7
+    "@vitest/browser": ^4.1.9
+    "@vitest/browser-playwright": ^4.1.9
+    "@vitest/coverage-istanbul": ^4.1.9
     "@vitest/eslint-plugin": ^1.6.18
     babel-plugin-istanbul: ^7.0.0
     babel-plugin-mockable-imports: ^2.0.1
@@ -9524,7 +9460,7 @@ __metadata:
     terser: ^5.39.0
     typescript: ^6.0.3
     typescript-eslint: ^8.53.1
-    vitest: ^4.1.7
+    vitest: ^4.1.9
   languageName: unknown
   linkType: soft
 
@@ -9644,17 +9580,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "vitest@npm:4.1.7"
+"vitest@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "vitest@npm:4.1.9"
   dependencies:
-    "@vitest/expect": 4.1.7
-    "@vitest/mocker": 4.1.7
-    "@vitest/pretty-format": 4.1.7
-    "@vitest/runner": 4.1.7
-    "@vitest/snapshot": 4.1.7
-    "@vitest/spy": 4.1.7
-    "@vitest/utils": 4.1.7
+    "@vitest/expect": 4.1.9
+    "@vitest/mocker": 4.1.9
+    "@vitest/pretty-format": 4.1.9
+    "@vitest/runner": 4.1.9
+    "@vitest/snapshot": 4.1.9
+    "@vitest/spy": 4.1.9
+    "@vitest/utils": 4.1.9
     es-module-lexer: ^2.0.0
     expect-type: ^1.3.0
     magic-string: ^0.30.21
@@ -9672,12 +9608,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.7
-    "@vitest/browser-preview": 4.1.7
-    "@vitest/browser-webdriverio": 4.1.7
-    "@vitest/coverage-istanbul": 4.1.7
-    "@vitest/coverage-v8": 4.1.7
-    "@vitest/ui": 4.1.7
+    "@vitest/browser-playwright": 4.1.9
+    "@vitest/browser-preview": 4.1.9
+    "@vitest/browser-webdriverio": 4.1.9
+    "@vitest/coverage-istanbul": 4.1.9
+    "@vitest/coverage-v8": 4.1.9
+    "@vitest/ui": 4.1.9
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -9707,8 +9643,8 @@ __metadata:
     vite:
       optional: false
   bin:
-    vitest: vitest.mjs
-  checksum: fb94346e03d5add104392e7fc450475b27c0f3bceb9cc80e5706b9695ee4bc74dcb53938ba2d0e47ed5d4279cc9d258cf4d1139307662ed360c5aaa38aa2e34f
+    vitest: ./vitest.mjs
+  checksum: 98b97fd79f02357c0f96dcdcda588467c1a341542700bf631cd88e135284300216300a0c7a8eaae8a0c7f7730e2ae8eb5137d2bd507993fd42078c345a32dabf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What
Bumps the entire `@vitest/*` test-runner toolchain to **4.1.9** and regenerates `yarn.lock`.

## Why
The Vanta SOC2 test *"Critical vulnerabilities identified in packages are addressed (GitHub Repo)"* (DUE_SOON) flags a critical Dependabot alert that a single-package bump does **not** clear: `@vitest/browser` was already at 4.1.8, but `vitest`/`@vitest/browser-playwright@4.1.7` dragged a stale, vulnerable `@vitest/browser@4.1.7` back into the lockfile. Aligning the whole group dedupes it to a single `@vitest/browser@4.1.9`.

Clears critical Dependabot alert:
- **CVE-2026-53633** (@vitest/browser <= 4.1.7)

## Notes
- Dev-dependencies only (test runner) — no runtime/prod surface.
- Opened as **draft**: review + merge when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
